### PR TITLE
ADR0009 Pull Request template and communication guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -19,7 +19,7 @@ e.g. This includes a migration, model and controller for user authentication. I'
 
 ## Testing?
 
-{Including tests along with code updates is essential as it prevents merging code without tests or failing tests, which could pose risks if overlooked. It's equally important to describe how you've tested harder-to-test codes, like infrastructure code, and to communicate any untested conditions or edge cases and their associated risks to the reviewer.}
+{Including tests along with code updates is essential as it prevents merging code without tests or failing tests, which could pose risks if overlooked. It's equally important to describe how you've tested harder-to-test code, like infrastructure code, and to communicate any untested conditions or edge cases and their associated risks to the reviewer.}
 
 ## Screenshots (optional)
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,43 @@
+## What?
+
+{Please write a few concise sentences outlining your changes and their overall impact, avoiding overly technical language. Reference relevant issue tracker tickets, but provide a stand-alone description that doesn’t require more than a few seconds to grasp.
+
+e.g. I've added support for authentication to implement feature X of service Y. It
+includes model, table, controller and test. For more background, see ticket #JIRA-123.}
+
+## Why?
+
+{Outlining the business or engineering goals this Pull Request accomplishes is often more important than the "what". For instance, adding an environment variable default value may appear uncomplicated to many. However, if it drastically alters the usage of libraries in your application, an active-voiced explanation is needed to capture the true impact of the change.
+
+e.g. These changes complete the user login and account creation experience. See #JIRA-123 for more information.}
+
+## How?
+
+{While the Pull Request diff illustrates the "how" of your changes, it's crucial to highlight major design decisions like choosing a recursive method over a loop. Explaining your reasoning helps reviewers understand your thought process and enables a more insightful review.
+
+e.g. This includes a migration, model and controller for user authentication. I'm using Devise to do the heavy lifting. I ran Devise migrations and those are included here.}
+
+## Testing?
+
+{Including tests along with code updates is essential as it prevents merging code without tests or failing tests, which could pose risks if overlooked. It's equally important to describe how you've tested harder-to-test codes, like infrastructure code, and to communicate any untested conditions or edge cases and their associated risks to the reviewer.}
+
+## Screenshots (optional)
+
+{Screenshots can significantly aid the review process, especially for UI-related changes, by offering before-and-after views. Even for backend code, a snapshot of the outcome, such as a CLI tool output, can be insightful. For infrastructure code, consider including the result of operations like a Terraform plan, preferably in a collapsible section, to avoid cluttering the comment space.
+
+Here’s how to do it in GitHub:
+```
+<details>
+  <summary>Terraform Plan</summary>
+
+  ### After running plan:
+</details>
+```
+}
+
+## Anything Else?
+
+{Consider discussing potential architectural modifications and technical debt while highlighting any challenges or optimisations you have identified.
+
+e.g. Let's consider using a 3rd party authentication provider for this, to offload MFA and other considerations as they arise and the privacy landscape evolves. AWS Cognito is a good option, so is Firebase. I'm happy to start researching this path.
+Let's also consider breaking this out into its own service. We can then re-use it or share the accounts with other apps in the future.}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decided on Cabin as our Software-as-a-Service (SaaS) Web Analytics Solution
 - Added a Decision Record issue template
 - Added a panel for README badges and an HDI Way of Working badge
+- Added a Pull Request template and communications guidelines
 
 ## [1.0.0] - 2023-02-17
 

--- a/docs/decisions/0009-pull-request-guidlines-and-template.md
+++ b/docs/decisions/0009-pull-request-guidlines-and-template.md
@@ -1,0 +1,32 @@
+---
+# Configuration for the Jekyll template "Just the Docs"
+nav_order: 9
+parent: Decision Records
+
+# These are optional elements. Feel free to remove any of them.
+status: proposed
+date: 2023-05-24
+---
+# Pull Request guidlines and template
+
+## Context and Problem Statement
+
+The structure of a Pull Request (PR) can take many forms, making it difficult to understand at a glance the what, why and how of a PR. Which form should we choose?
+
+## Considered Options
+
+* Formless – No conventions for PR format and structure
+* [What? Why? How? Testing? Screenshots (optional) Anything Else?](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)
+* [GitHub pull request template](https://axolo.co/blog/p/part-3-github-pull-request-template) examples
+* [How to Write a Proper Description for a Pull Request](https://maddevs.io/blog/how-to-make-a-proper-description-for-a-pull-request/)
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because
+{justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
+
+Although not a template format, we should also include GitHub's communication guidlines in [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/).
+
+## More Information
+
+Whichever format is chosen, we should create an initialiser to add the GitHub [PR template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) to a project.

--- a/docs/decisions/0009-pull-request-guidlines-and-template.md
+++ b/docs/decisions/0009-pull-request-guidlines-and-template.md
@@ -4,7 +4,7 @@ nav_order: 9
 parent: Decision Records
 
 # These are optional elements. Feel free to remove any of them.
-status: proposed
+status: accepted
 date: 2023-05-24
 ---
 # Pull Request guidlines and template

--- a/docs/pull-request-template-and-guidelines.md
+++ b/docs/pull-request-template-and-guidelines.md
@@ -1,0 +1,18 @@
+---
+layout: page
+---
+
+# Pull Request Template and Guidlines
+
+A Pull Request (PR) template offers multiple benefits to a development team. It standardizes the process of contributing changes, making it easier for both the author and the reviewers to understand the context of the changes. PR templates can ensure that necessary details, such as a summary of the changes, the reason for the changes (the 'why'), and any associated issue or ticket numbers, are consistently provided. This helps in maintaining a clean, organized, and searchable project history.
+
+Moreover, by setting clear expectations about the information that should be included in a PR, templates can streamline the review process, reduce the likelihood of misunderstandings, and ultimately lead to higher-quality code and a more productive team.
+
+{: .important }
+A Pull Request doesn't begin and end with the template, the tone of the request and any subsequent feedback is also very important. Alongside the [Code of Conduct](code-of-conduct.md), please read GitHub's PR communication guidlines in [How to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/).
+
+## Usage
+
+To add the Pull Request template to your project, use the following at the command line:
+
+    way_of_working init pr_template

--- a/lib/way_of_working/cli.rb
+++ b/lib/way_of_working/cli.rb
@@ -8,6 +8,7 @@ require_relative 'generators/inclusive_language/exec'
 require_relative 'generators/inclusive_language/init'
 require_relative 'generators/linter/exec'
 require_relative 'generators/linter/init'
+require_relative 'generators/pr_template/init'
 require_relative 'generators/rake_tasks/init'
 require_relative 'generators/readme_badge/init'
 require_relative 'sub_command_base'
@@ -105,6 +106,18 @@ module WayOfWorking
 
                    This will create:
                        .alexrc
+             LONGDESC
+
+    register(Generators::PrTemplate::Init, 'pr_template', 'pr_template',
+             <<~LONGDESC)
+               Description:
+                   Installs the Pull Request template into the project
+
+               Example:
+                   way_of_working init pr_template
+
+                   This will create:
+                       .github/PULL_REQUEST_TEMPLATE/pull_request_template.md
              LONGDESC
 
     register(Generators::RakeTasks::Init, 'rake_tasks', 'rake_tasks',

--- a/lib/way_of_working/generators/pr_template/init.rb
+++ b/lib/way_of_working/generators/pr_template/init.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'thor'
+require 'way_of_working/paths'
+
+module WayOfWorking
+  module Generators
+    module PrTemplate
+      # This generator add the Pull Request template to a project
+      class Init < Thor::Group
+        include Thor::Actions
+
+        source_root ::WayOfWorking.source_root
+
+        def copy_pr_template_action
+          copy_file '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md'
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/generators/pr_template/init.rb
+++ b/lib/way_of_working/generators/pr_template/init.rb
@@ -6,7 +6,7 @@ require 'way_of_working/paths'
 module WayOfWorking
   module Generators
     module PrTemplate
-      # This generator add the Pull Request template to a project
+      # This generator adds the Pull Request template to a project
       class Init < Thor::Group
         include Thor::Actions
 

--- a/lib/way_of_working/templates/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/lib/way_of_working/templates/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -19,7 +19,7 @@ e.g. This includes a migration, model and controller for user authentication. I'
 
 ## Testing?
 
-{Including tests along with code updates is essential as it prevents merging code without tests or failing tests, which could pose risks if overlooked. It's equally important to describe how you've tested harder-to-test codes, like infrastructure code, and to communicate any untested conditions or edge cases and their associated risks to the reviewer.}
+{Including tests along with code updates is essential as it prevents merging code without tests or failing tests, which could pose risks if overlooked. It's equally important to describe how you've tested harder-to-test code, like infrastructure code, and to communicate any untested conditions or edge cases and their associated risks to the reviewer.}
 
 ## Screenshots (optional)
 

--- a/lib/way_of_working/templates/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/lib/way_of_working/templates/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,43 @@
+## What?
+
+{Please write a few concise sentences outlining your changes and their overall impact, avoiding overly technical language. Reference relevant issue tracker tickets, but provide a stand-alone description that doesn’t require more than a few seconds to grasp.
+
+e.g. I've added support for authentication to implement feature X of service Y. It
+includes model, table, controller and test. For more background, see ticket #JIRA-123.}
+
+## Why?
+
+{Outlining the business or engineering goals this Pull Request accomplishes is often more important than the "what". For instance, adding an environment variable default value may appear uncomplicated to many. However, if it drastically alters the usage of libraries in your application, an active-voiced explanation is needed to capture the true impact of the change.
+
+e.g. These changes complete the user login and account creation experience. See #JIRA-123 for more information.}
+
+## How?
+
+{While the Pull Request diff illustrates the "how" of your changes, it's crucial to highlight major design decisions like choosing a recursive method over a loop. Explaining your reasoning helps reviewers understand your thought process and enables a more insightful review.
+
+e.g. This includes a migration, model and controller for user authentication. I'm using Devise to do the heavy lifting. I ran Devise migrations and those are included here.}
+
+## Testing?
+
+{Including tests along with code updates is essential as it prevents merging code without tests or failing tests, which could pose risks if overlooked. It's equally important to describe how you've tested harder-to-test codes, like infrastructure code, and to communicate any untested conditions or edge cases and their associated risks to the reviewer.}
+
+## Screenshots (optional)
+
+{Screenshots can significantly aid the review process, especially for UI-related changes, by offering before-and-after views. Even for backend code, a snapshot of the outcome, such as a CLI tool output, can be insightful. For infrastructure code, consider including the result of operations like a Terraform plan, preferably in a collapsible section, to avoid cluttering the comment space.
+
+Here’s how to do it in GitHub:
+```
+<details>
+  <summary>Terraform Plan</summary>
+
+  ### After running plan:
+</details>
+```
+}
+
+## Anything Else?
+
+{Consider discussing potential architectural modifications and technical debt while highlighting any challenges or optimisations you have identified.
+
+e.g. Let's consider using a 3rd party authentication provider for this, to offload MFA and other considerations as they arise and the privacy landscape evolves. AWS Cognito is a good option, so is Firebase. I'm happy to start researching this path.
+Let's also consider breaking this out into its own service. We can then re-use it or share the accounts with other apps in the future.}

--- a/test/generators/pr_template/init_test.rb
+++ b/test/generators/pr_template/init_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+module WayOfWorking
+  module Generators
+    module PrTemplate
+      # This class tests the PrTemplate::Init Thor Group (generator)
+      class InitTest < Rails::Generators::TestCase
+        tests WayOfWorking::Generators::PrTemplate::Init
+        destination WayOfWorking.root.join('tmp/generators')
+        setup :prepare_destination
+
+        test 'generator runs without errors' do
+          assert_nothing_raised do
+            run_generator
+          end
+        end
+
+        test 'files are created and revoked' do
+          run_generator
+
+          assert_file '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md'
+
+          run_generator [], behavior: :revoke
+
+          assert_no_file '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What?

I've added a Pull Request template and command to add it to projects.

## Why?

Having a Pull Request (PR) template offers multiple benefits to a development team. It standardises the process of contributing changes, making it easier for both the author and the reviewers to understand the context and impact of the changes.

## How?

This includes a Thor `init` command, template markdown file and documentation for the GitHub pages site.

## Testing?

This commit includes a Thor test.

## Screenshots (optional)

0

## Anything Else?

The documentation references the GitHub communication guidelines with advice on the tone and approach to writing PRs and responding to them.
