### PR TITLE
Non-git repos don't break the Changelog generator. Fixes #52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a panel for README badges and an HDI Way of Working badge
 - Added a Pull Request template and communications guidelines
 
+### Fixed
+
+- A Changelog can now be created in project that hasn't been initialised as a git repository
+
 ## [1.0.0] - 2023-02-17
 
 ### Added

--- a/lib/way_of_working/generators/changelog/init.rb
+++ b/lib/way_of_working/generators/changelog/init.rb
@@ -99,6 +99,8 @@ module WayOfWorking
 
         def summary_tags
           @summary_tags ||= repo_reader.summary_tags.reverse
+        rescue ArgumentError
+          []
         end
 
         def url


### PR DESCRIPTION
## What?

I've fixed an issue where generating a Changelog required the project to already be a git repo.

## Why?

The command line tool would crash when trying to create a changelog in a non-git project. See #52 for details.

## How?

This fix gracefully handles the absence of a git repo by catching the error and returning an empty array of summary tags.

## Testing?

I have tested this locally by renaming the `.git` folder of this project to `dotgit` and running the generator.

