### PR TITLE
Added a Thor command to update the list of used and available linters

### DIFF
--- a/docs/code-linting/linters.md
+++ b/docs/code-linting/linters.md
@@ -16,10 +16,12 @@ The following tables detail the linters that we are currently using:
 | Bash         | BASH_SHELLCHECK                     | [shellcheck](https://megalinter.io/latest/descriptors/bash_shellcheck/)         |
 | Bash         | BASH_SHFMT                          | [shfmt](https://megalinter.io/latest/descriptors/bash_shfmt/)                   |
 | C            | C_CPPLINT                           | [cpplint](https://megalinter.io/latest/descriptors/c_cpplint/)                  |
+| C#           | ~~CSHARP_CSHARPIER~~                | Not Used                                                                        |
+| C#           | CSHARP_DOTNET_FORMAT                | [dotnet-format](https://megalinter.io/latest/descriptors/csharp_dotnet_format/) |
+| C++          | CPP_CPPLINT                         | [cpplint](https://megalinter.io/latest/descriptors/cpp_cpplint/)                |
+| Clojure      | ~~CLOJURE_CLJSTYLE~~                | Not Used                                                                        |
 | Clojure      | ~~CLOJURE_CLJ_KONDO~~               | Not Used                                                                        |
 | CoffeeScript | COFFEE_COFFEELINT                   | [coffeelint](https://megalinter.io/latest/descriptors/coffee_coffeelint/)       |
-| C++          | CPP_CPPLINT                         | [cpplint](https://megalinter.io/latest/descriptors/cpp_cpplint/)                |
-| C#           | CSHARP_DOTNET_FORMAT                | [dotnet-format](https://megalinter.io/latest/descriptors/csharp_dotnet_format/) |
 | Dart         | DART_DARTANALYZER                   | [dartanalyzer](https://megalinter.io/latest/descriptors/dart_dartanalyzer/)     |
 | Go           | GO_GOLANGCI_LINT                    | [golangci-lint](https://megalinter.io/latest/descriptors/go_golangci_lint/)     |
 | Go           | GO_REVIVE                           | [revive](https://megalinter.io/latest/descriptors/go_revive/)                   |
@@ -47,6 +49,7 @@ The following tables detail the linters that we are currently using:
 | Python       | PYTHON_MYPY                         | [mypy](https://megalinter.io/latest/descriptors/python_mypy/)                   |
 | Python       | PYTHON_PYLINT                       | [pylint](https://megalinter.io/latest/descriptors/python_pylint/)               |
 | Python       | PYTHON_PYRIGHT                      | [pyright](https://megalinter.io/latest/descriptors/python_pyright/)             |
+| Python       | ~~PYTHON_RUFF~~                     | Not Used                                                                        |
 | R            | R_LINTR                             | [lintr](https://megalinter.io/latest/descriptors/r_lintr/)                      |
 | Raku         | ~~RAKU_RAKU~~                       | Not Used                                                                        |
 | Ruby         | ~~RUBY_RUBOCOP~~                    | Not Used (RuboCop is used directly)                                             |
@@ -55,8 +58,8 @@ The following tables detail the linters that we are currently using:
 | Salesforce   | ~~SALESFORCE_SFDX_SCANNER_AURA~~    | Not Used                                                                        |
 | Salesforce   | ~~SALESFORCE_SFDX_SCANNER_LWC~~     | Not Used                                                                        |
 | Scala        | SCALA_SCALAFIX                      | [scalafix](https://megalinter.io/latest/descriptors/scala_scalafix/)            |
-| SQL          | SQL_SQL_LINT                        | [sql-lint](https://megalinter.io/latest/descriptors/sql_sql_lint/)              |
 | SQL          | SQL_SQLFLUFF                        | [sqlfluff](https://megalinter.io/latest/descriptors/sql_sqlfluff/)              |
+| SQL          | SQL_SQL_LINT                        | [sql-lint](https://megalinter.io/latest/descriptors/sql_sql_lint/)              |
 | SQL          | SQL_TSQLLINT                        | [tsqllint](https://megalinter.io/latest/descriptors/sql_tsqllint/)              |
 | Swift        | SWIFT_SWIFTLINT                     | [swiftlint](https://megalinter.io/latest/descriptors/swift_swiftlint/)          |
 | TSX          | TSX_ESLINT                          | [eslint](https://megalinter.io/latest/descriptors/tsx_eslint/)                  |
@@ -90,12 +93,13 @@ The following tables detail the linters that we are currently using:
 | reStructuredText | ~~RST_RSTFMT~~                    | Not Used                                                                                                |
 | reStructuredText | ~~RST_RST_LINT~~                  | Not Used                                                                                                |
 | XML              | XML_XMLLINT                       | [xmllint](https://megalinter.io/latest/descriptors/xml_xmllint/)                                        |
+| YAML             | ~~YAML_PRETTIER~~                 | Not Used                                                                                                |
 | YAML             | YAML_V8R                          | [v8r](https://megalinter.io/latest/descriptors/yaml_v8r/)                                               |
 | YAML             | YAML_YAMLLINT                     | [yamllint](https://megalinter.io/latest/descriptors/yaml_yamllint/)                                     |
 
-## Tooling
+## Tooling formats
 
-| Tooling Format | Linter                            | Details                                                                                             |
+| Tooling format | Linter                            | Details                                                                                             |
 |:---------------|:----------------------------------|:----------------------------------------------------------------------------------------------------|
 | GitHub Action  | ACTION_ACTIONLINT                 | [actionlint](https://megalinter.io/latest/descriptors/action_actionlint/)                           |
 | Ansible        | ANSIBLE_ANSIBLE_LINT              | [ansible-lint](https://megalinter.io/latest/descriptors/ansible_ansible_lint/)                      |
@@ -105,35 +109,35 @@ The following tables detail the linters that we are currently using:
 | Dockerfile     | DOCKERFILE_HADOLINT               | [hadolint](https://megalinter.io/latest/descriptors/dockerfile_hadolint/)                           |
 | EditorConfig   | EDITORCONFIG_EDITORCONFIG_CHECKER | [editorconfig-checker](https://megalinter.io/latest/descriptors/editorconfig_editorconfig_checker/) |
 | Gherkin        | ~~GHERKIN_GHERKIN_LINT~~          | Not Used                                                                                            |
+| Kubernetes     | ~~KUBERNETES_HELM~~               | Not Used                                                                                            |
 | Kubernetes     | KUBERNETES_KUBECONFORM            | [kubeconform](https://megalinter.io/latest/descriptors/kubernetes_kubeconform/)                     |
-| Kubernetes     | KUBERNETES_KUBEVAL                | [kubeval](https://megalinter.io/latest/descriptors/kubernetes_kubeval/)                             |
-| OpenAPI        | OPENAPI_SPECTRAL                  | [spectral](https://megalinter.io/latest/descriptors/openapi_spectral/)                              |
+| Kubernetes     | ~~KUBERNETES_KUBESCAPE~~          | Not Used                                                                                            |
+| Openapi        | OPENAPI_SPECTRAL                  | [spectral](https://megalinter.io/latest/descriptors/openapi_spectral/)                              |
 | Puppet         | PUPPET_PUPPET_LINT                | [puppet-lint](https://megalinter.io/latest/descriptors/puppet_puppet_lint/)                         |
 | Snakemake      | ~~SNAKEMAKE_LINT~~                | Not Used                                                                                            |
 | Snakemake      | ~~SNAKEMAKE_SNAKEFMT~~            | Not Used                                                                                            |
 | Tekton         | ~~TEKTON_TEKTON_LINT~~            | Not Used                                                                                            |
-| Terraform      | TERRAFORM_CHECKOV                 | [checkov](https://megalinter.io/latest/descriptors/terraform_checkov/)                              |
-| Terraform      | TERRAFORM_KICS                    | [kics](https://megalinter.io/latest/descriptors/terraform_kics/)                                    |
 | Terraform      | TERRAFORM_TERRAFORM_FMT           | [terraform-fmt](https://megalinter.io/latest/descriptors/terraform_terraform_fmt/)                  |
 | Terraform      | TERRAFORM_TERRAGRUNT              | [terragrunt](https://megalinter.io/latest/descriptors/terraform_terragrunt/)                        |
 | Terraform      | TERRAFORM_TERRASCAN               | [terrascan](https://megalinter.io/latest/descriptors/terraform_terrascan/)                          |
 | Terraform      | TERRAFORM_TFLINT                  | [tflint](https://megalinter.io/latest/descriptors/terraform_tflint/)                                |
 
-## Code quality checkers
+## Other
 
-| Code quality check | Linter                | Details                                                                       |
-|:-------------------|:----------------------|:------------------------------------------------------------------------------|
-| Duplication        | COPYPASTE_JSCPD       | [jscpd](https://megalinter.io/latest/descriptors/copypaste_jscpd/)            |
-| Repository         | REPOSITORY_CHECKOV    | [checkov](https://megalinter.io/latest/descriptors/repository_checkov/)       |
-| Repository         | REPOSITORY_DEVSKIM    | [devskim](https://megalinter.io/latest/descriptors/repository_devskim/)       |
-| Repository         | REPOSITORY_DUSTILOCK  | [dustilock](https://megalinter.io/latest/descriptors/repository_dustilock/)   |
-| Repository         | REPOSITORY_GITLEAKS   | [gitleaks](https://megalinter.io/latest/descriptors/repository_gitleaks/)     |
-| Repository         | REPOSITORY_GIT_DIFF   | [git_diff](https://megalinter.io/latest/descriptors/repository_git_diff/)     |
-| Repository         | REPOSITORY_GOODCHECK  | [goodcheck](https://megalinter.io/latest/descriptors/repository_goodcheck/)   |
-| Repository         | REPOSITORY_SECRETLINT | [secretlint](https://megalinter.io/latest/descriptors/repository_secretlint/) |
-| Repository         | REPOSITORY_SEMGREP    | [semgrep](https://megalinter.io/latest/descriptors/repository_semgrep/)       |
-| Repository         | REPOSITORY_SYFT       | [syft](https://megalinter.io/latest/descriptors/repository_syft/)             |
-| Repository         | REPOSITORY_TRIVY      | [trivy](https://megalinter.io/latest/descriptors/repository_trivy/)           |
-| Spelling           | ~~SPELL_CSPELL~~      | Not Used                                                                      |
-| Spelling           | SPELL_MISSPELL        | [misspell](https://megalinter.io/latest/descriptors/spell_misspell/)          |
-| Spelling           | SPELL_PROSELINT       | [proselint](https://megalinter.io/latest/descriptors/spell_proselint/)        |
+| Other      | Linter                | Details                                                                       |
+|:-----------|:----------------------|:------------------------------------------------------------------------------|
+| Copypaste  | COPYPASTE_JSCPD       | [jscpd](https://megalinter.io/latest/descriptors/copypaste_jscpd/)            |
+| Repository | REPOSITORY_CHECKOV    | [checkov](https://megalinter.io/latest/descriptors/repository_checkov/)       |
+| Repository | REPOSITORY_DEVSKIM    | [devskim](https://megalinter.io/latest/descriptors/repository_devskim/)       |
+| Repository | REPOSITORY_DUSTILOCK  | [dustilock](https://megalinter.io/latest/descriptors/repository_dustilock/)   |
+| Repository | REPOSITORY_GITLEAKS   | [gitleaks](https://megalinter.io/latest/descriptors/repository_gitleaks/)     |
+| Repository | REPOSITORY_GIT_DIFF   | [git_diff](https://megalinter.io/latest/descriptors/repository_git_diff/)     |
+| Repository | ~~REPOSITORY_KICS~~   | Not Used                                                                      |
+| Repository | REPOSITORY_SECRETLINT | [secretlint](https://megalinter.io/latest/descriptors/repository_secretlint/) |
+| Repository | REPOSITORY_SEMGREP    | [semgrep](https://megalinter.io/latest/descriptors/repository_semgrep/)       |
+| Repository | REPOSITORY_SYFT       | [syft](https://megalinter.io/latest/descriptors/repository_syft/)             |
+| Repository | REPOSITORY_TRIVY      | [trivy](https://megalinter.io/latest/descriptors/repository_trivy/)           |
+| Spelling   | ~~SPELL_CSPELL~~      | Not Used                                                                      |
+| Spelling   | SPELL_PROSELINT       | [proselint](https://megalinter.io/latest/descriptors/spell_proselint/)        |
+| Spelling   | ~~SPELL_VALE~~        | Not Used                                                                      |
+

--- a/lib/way_of_working/cli.rb
+++ b/lib/way_of_working/cli.rb
@@ -6,6 +6,7 @@ require_relative 'generators/decision_record/init'
 require_relative 'generators/decision_record/new'
 require_relative 'generators/inclusive_language/exec'
 require_relative 'generators/inclusive_language/init'
+require_relative 'generators/linter/document'
 require_relative 'generators/linter/exec'
 require_relative 'generators/linter/init'
 require_relative 'generators/pr_template/init'
@@ -14,6 +15,18 @@ require_relative 'generators/readme_badge/init'
 require_relative 'sub_command_base'
 
 module WayOfWorking
+  # This class defines the document parent command
+  class Document < SubCommandBase
+    register(Generators::Linter::Document, 'linter', 'linter',
+             <<~LONGDESC)
+               Description:
+                   This documents the linter on this project
+
+               Example:
+                   way_of_working document linter
+             LONGDESC
+  end
+
   # This class defines the exec (i.e. run) parent command
   class Exec < SubCommandBase
     register(Generators::Linter::Exec, 'linter', 'linter',
@@ -170,5 +183,8 @@ module WayOfWorking
 
     desc 'exec [COMPONENT]', 'Executes (runs) the specific component'
     subcommand 'exec', Exec
+
+    desc 'document [COMPONENT]', 'Documents the specific component'
+    subcommand 'document', Document
   end
 end

--- a/lib/way_of_working/generators/linter/document.rb
+++ b/lib/way_of_working/generators/linter/document.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/string'
+require 'nokogiri'
+require 'open-uri'
+require 'thor'
+require 'way_of_working/paths'
+
+module WayOfWorking
+  module Generators
+    module Linter
+      # Struct to hold linter data
+      class SupportedLinter
+        # Reasons why certain linters are not used
+        NOT_USED_REASON = {
+          'CSS_SCSS_LINT' => 'scss-lint recommends using stylelint',
+          'HTML_DJLINT' => 'Refuses to see config file',
+          'RUBY_RUBOCOP' => 'RuboCop is used directly'
+        }.freeze
+
+        # Acronyms for languages
+        TLA_LANGUAGES = %w[
+          CSS
+          ENV
+          HTML
+          JSON
+          JSX
+          PHP
+          SQL
+          TSX
+          XML
+          YAML
+        ].freeze
+
+        # Mapping for languages
+        LANGUAGE_MAPPINGS = {
+          'Action' => 'GitHub Action',
+          'Arm' => 'ARM Templates',
+          'Cloudformation' => 'CloudFormation',
+          'Coffee' => 'CoffeeScript',
+          'Editorconfig' => 'EditorConfig',
+          'Graphql' => 'GraphQL',
+          'Javascript' => 'JavaScript',
+          'Latex' => 'LaTeX',
+          'Protobuf' => 'Protocol Buffers',
+          'Rst' => 'reStructuredText',
+          'Spell' => 'Spelling',
+          'Typescript' => 'TypeScript',
+          'Visual Basic .Net' => 'VB.Net'
+        }.freeze
+
+        attr_accessor :name, :link, :enabled_linters, :sorter
+
+        def initialize(language, constant_name, name, link, enabled_linters)
+          @original_language = language
+          @original_constant_name = constant_name
+          @name = name
+          @link = link
+          @enabled_linters = enabled_linters
+
+          # Array used for sorting
+          @sorter = [@original_language, @original_constant_name]
+        end
+
+        def language
+          language = @original_language
+
+          # Titleize language unless it is an acronym
+          language = language.titleize unless TLA_LANGUAGES.include?(language)
+
+          # Use mapped language name if available
+          language = LANGUAGE_MAPPINGS[language] if LANGUAGE_MAPPINGS.key?(language)
+
+          language
+        end
+
+        def constant_name
+          return @original_constant_name if enabled_linters.include?(@original_constant_name)
+
+          # Strike-through the constant name if the linter is not used
+          "~~#{@original_constant_name}~~"
+        end
+
+        def details
+          return "[#{name}](#{link})" if enabled_linters.include?(@original_constant_name)
+
+          details = 'Not Used'
+
+          # Add reason if available
+          if NOT_USED_REASON.key?(@original_constant_name)
+            details = "#{details} (#{NOT_USED_REASON[@original_constant_name]})"
+          end
+
+          details
+        end
+      end
+
+      # This class is responsible for generating linter documentation
+      class Document < Thor::Group
+        include Thor::Actions # Mixin for action methods provided by Thor
+
+        # Set the source root for the templates
+        source_root ::WayOfWorking.source_root
+
+        # URL of the supported linters
+        SUPPORTED_LINTERS_URL = 'https://megalinter.io/latest/supported-linters/'
+
+        # Method to prepare the list of linters from the supported linters URL
+        def prepare_linter_lists
+          # Initialize an empty hash for linter types
+          @types = {}
+
+          # Iterate over each linter type in the parsed HTML
+          parse_linter_types_html do |type, html_rows|
+            @types[type] = []
+
+            parse_linter_rows(html_rows) do |constant_name, language, name, link|
+              # Create a new linter object and add it to the list
+              @types[type] << SupportedLinter.new(language, constant_name, name, link,
+                                                  enabled_linters)
+            end
+          end
+        end
+
+        # Method to create the linter documentation using a template
+        def create_linters_documentation
+          template 'docs/code-linting/linters.md'
+        end
+
+        private
+
+        def parse_linter_types_html
+          # Parse HTML from the supported linters URL
+          doc = Nokogiri::HTML(URI.parse(SUPPORTED_LINTERS_URL).read)
+
+          doc.css('article h2').each do |h2|
+            type = h2.text.strip
+
+            yield type, h2.next_element.css('tbody tr')
+          end
+        end
+
+        def parse_linter_rows(html_rows)
+          # Iterate over each linter in the current type
+          html_rows.each do |tr|
+            tds = tr.css('td')
+            constant_name = tds[2].css('a')[1].text
+            language = tds[1].text.sub(/\s\([^)]+\)\z/, '')
+            name = tds[2].css('a')[0].text
+            link = tds[2].css('a')[0].attributes['href'].value.sub(/\A\.\./, 'https://megalinter.io/latest')
+
+            yield constant_name, language, name, link
+          end
+        end
+
+        # Load enabled linters from the YAML config file
+        def enabled_linters
+          @enabled_linters ||= YAML.load_file('.mega-linter.yml')['ENABLE_LINTERS']
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/generators/linter/init.rb
+++ b/lib/way_of_working/generators/linter/init.rb
@@ -6,7 +6,7 @@ require 'way_of_working/paths'
 module WayOfWorking
   module Generators
     module Linter
-      # This generator add the MADR files to the doc/decisions folder
+      # This generator initialises the linter
       class Init < Thor::Group
         include Thor::Actions
 

--- a/lib/way_of_working/templates/docs/code-linting/linters.md
+++ b/lib/way_of_working/templates/docs/code-linting/linters.md
@@ -1,0 +1,24 @@
+---
+layout: page
+nav_order: 1
+parent: Code Linting
+---
+
+# Linters
+
+The following tables detail the linters that we are currently using:
+<% @types.each do |type, linters| -%>
+
+## <%= type %>
+
+<%
+max_language_length = linters.map(&:language).map(&:length).max
+max_constant_name_length = linters.map(&:constant_name).map(&:length).max
+max_details_length = linters.map(&:details).map(&:length).max
+-%>
+| <%= type.singularize.ljust(max_language_length) %> | <%= 'Linter'.ljust(max_constant_name_length) %> | <%= 'Details'.ljust(max_details_length) %> |
+|<%= ':'.ljust(max_language_length + 2, '-') %>|<%= ':'.ljust(max_constant_name_length + 2, '-') %>|<%= ':'.ljust(max_details_length + 2, '-') %>|
+<% linters.sort_by(&:sorter).each do |linter| -%>
+| <%= linter.language.ljust(max_language_length) %> | <%= linter.constant_name.ljust(max_constant_name_length) %> | <%= linter.details.ljust(max_details_length) %> |
+<% end -%>
+<% end %>

--- a/test/generators/linter/document_test.rb
+++ b/test/generators/linter/document_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+require 'way_of_working/generators/linter/document'
+
+module WayOfWorking
+  module Generators
+    module Linter
+      # This class tests the Linter::Init Thor Group (generator)
+      class DocumentTest < Rails::Generators::TestCase
+        tests WayOfWorking::Generators::Linter::Document
+        destination WayOfWorking.root.join('tmp/generators')
+        setup :prepare_destination
+
+        test 'generator runs without errors' do
+          assert_nothing_raised do
+            run_generator
+          end
+        end
+
+        test 'files are created and revoked' do
+          run_generator
+
+          assert_file 'docs/code-linting/linters.md'
+
+          run_generator [], behavior: :revoke
+
+          assert_no_file 'docs/code-linting/linters.md'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What?

I've added a Thor command to update the list of used and available linters.

## Why?

The list of linters can become stale. Manually updating it is extremely tedious.

## How?

This scrapes the Megalinter list of linters from the website and compares it with the configured list of used linters to (re)generate the documentation page.

## Testing?

A test has been added for the new generator.