### PR TITLE
Added the Xcode linting build phase

### DIFF
--- a/lib/way_of_working/generators/linter/init.rb
+++ b/lib/way_of_working/generators/linter/init.rb
@@ -12,6 +12,31 @@ module WayOfWorking
 
         source_root ::WayOfWorking.source_root
 
+        LINTING_BUILD_PHASE =
+          "				2F0882F42AAB152D00DB0B2B /* ShellScript */,\n"
+        LINTING_BUILD_PHASE_DETAILS = <<~CONFIG
+          /* Begin PBXShellScriptBuildPhase section */
+          \t\t2F0882F42AAB152D00DB0B2B /* ShellScript */ = {
+          \t\t\tisa = PBXShellScriptBuildPhase;
+          \t\t\tbuildActionMask = 2147483647;
+          \t\t\tfiles = (
+          \t\t\t);
+          \t\t\tinputFileListPaths = (
+          \t\t\t);
+          \t\t\tinputPaths = (
+          \t\t\t);
+          \t\t\toutputFileListPaths = (
+          \t\t\t);
+          \t\t\toutputPaths = (
+          \t\t\t);
+          \t\t\trunOnlyForDeploymentPostprocessing = 0;
+          \t\t\tshellPath = /bin/sh;
+          \t\t\tshellScript = "if [[ \\"$(uname -m)\\" == arm64 ]]; then\\n    export PATH=\\"/opt/homebrew/bin:$PATH\\"\\nfi\\n\\nif which swiftlint > /dev/null; then\\n  swiftlint\\nelse\\n  echo \\"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\\"\\nfi\\n";
+          \t\t};
+          /* End PBXShellScriptBuildPhase section */
+
+        CONFIG
+
         # TODO: copy_rubocop_github_workflow_action
 
         def copy_github_linters_rubocop_config_file
@@ -46,7 +71,24 @@ module WayOfWorking
           copy_file '.rubocop'
         end
 
+        def inject_swiftlint_into_xcode_project_build_process
+          return unless xcode_project_file && File.exist?(xcode_project_file)
+
+          inject_into_file xcode_project_file,
+                           LINTING_BUILD_PHASE,
+                           after: "buildPhases = (\n"
+
+          inject_into_file xcode_project_file,
+                           LINTING_BUILD_PHASE_DETAILS,
+                           after: "/* End PBXResourcesBuildPhase section */\n\n"
+        end
+
         private
+
+        def xcode_project_file
+          puts Dir.glob(File.join(destination_root)).inspect
+          Dir.glob(File.join(destination_root, '*.xcodeproj/project.pbxproj')).first
+        end
 
         def create_file_if_missing(path)
           path = File.join(destination_root, path)

--- a/test/generators/linter/init_test.rb
+++ b/test/generators/linter/init_test.rb
@@ -42,6 +42,34 @@ module WayOfWorking
             refute_match(".rubocop-https---*\n", content)
           end
         end
+
+        test 'swiftlint build phase added to xcode project' do
+          prepare_xcode_project
+
+          run_generator
+
+          assert_file 'XcodeApp.xcodeproj/project.pbxproj' do |content|
+            assert_match(Init::LINTING_BUILD_PHASE, content)
+            assert_match(Init::LINTING_BUILD_PHASE_DETAILS, content)
+          end
+
+          run_generator [], behavior: :revoke
+
+          assert_file 'XcodeApp.xcodeproj/project.pbxproj' do |content|
+            refute_match(Init::LINTING_BUILD_PHASE, content)
+            refute_match(Init::LINTING_BUILD_PHASE_DETAILS, content)
+          end
+        end
+
+      private
+
+        # This method will copy a vanilla Rakefile into the destination folder
+        def prepare_xcode_project
+          xcode_project_destination_directory = destination_root.join('XcodeApp.xcodeproj')
+          FileUtils.mkdir(xcode_project_destination_directory)
+          FileUtils.copy WayOfWorking.root.join('test', 'resources', 'XcodeApp.xcodeproj', 'project.pbxproj'),
+                         xcode_project_destination_directory.join('project.pbxproj')
+        end
       end
     end
   end

--- a/test/resources/XcodeApp.xcodeproj/project.pbxproj
+++ b/test/resources/XcodeApp.xcodeproj/project.pbxproj
@@ -1,0 +1,344 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2FF0B6102AAF5257001F5DEE /* XcodeAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF0B60F2AAF5257001F5DEE /* XcodeAppApp.swift */; };
+		2FF0B6122AAF5257001F5DEE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF0B6112AAF5257001F5DEE /* ContentView.swift */; };
+		2FF0B6142AAF5258001F5DEE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2FF0B6132AAF5258001F5DEE /* Assets.xcassets */; };
+		2FF0B6172AAF5258001F5DEE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2FF0B6162AAF5258001F5DEE /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		2FF0B60C2AAF5257001F5DEE /* XcodeApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XcodeApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2FF0B60F2AAF5257001F5DEE /* XcodeAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeAppApp.swift; sourceTree = "<group>"; };
+		2FF0B6112AAF5257001F5DEE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		2FF0B6132AAF5258001F5DEE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		2FF0B6162AAF5258001F5DEE /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		2FF0B6092AAF5257001F5DEE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2FF0B6032AAF5257001F5DEE = {
+			isa = PBXGroup;
+			children = (
+				2FF0B60E2AAF5257001F5DEE /* XcodeApp */,
+				2FF0B60D2AAF5257001F5DEE /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		2FF0B60D2AAF5257001F5DEE /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				2FF0B60C2AAF5257001F5DEE /* XcodeApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		2FF0B60E2AAF5257001F5DEE /* XcodeApp */ = {
+			isa = PBXGroup;
+			children = (
+				2FF0B60F2AAF5257001F5DEE /* XcodeAppApp.swift */,
+				2FF0B6112AAF5257001F5DEE /* ContentView.swift */,
+				2FF0B6132AAF5258001F5DEE /* Assets.xcassets */,
+				2FF0B6152AAF5258001F5DEE /* Preview Content */,
+			);
+			path = XcodeApp;
+			sourceTree = "<group>";
+		};
+		2FF0B6152AAF5258001F5DEE /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				2FF0B6162AAF5258001F5DEE /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		2FF0B60B2AAF5257001F5DEE /* XcodeApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2FF0B61A2AAF5258001F5DEE /* Build configuration list for PBXNativeTarget "XcodeApp" */;
+			buildPhases = (
+				2FF0B6082AAF5257001F5DEE /* Sources */,
+				2FF0B6092AAF5257001F5DEE /* Frameworks */,
+				2FF0B60A2AAF5257001F5DEE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = XcodeApp;
+			productName = XcodeApp;
+			productReference = 2FF0B60C2AAF5257001F5DEE /* XcodeApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2FF0B6042AAF5257001F5DEE /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1430;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					2FF0B60B2AAF5257001F5DEE = {
+						CreatedOnToolsVersion = 14.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 2FF0B6072AAF5257001F5DEE /* Build configuration list for PBXProject "XcodeApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 2FF0B6032AAF5257001F5DEE;
+			productRefGroup = 2FF0B60D2AAF5257001F5DEE /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2FF0B60B2AAF5257001F5DEE /* XcodeApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		2FF0B60A2AAF5257001F5DEE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2FF0B6172AAF5258001F5DEE /* Preview Assets.xcassets in Resources */,
+				2FF0B6142AAF5258001F5DEE /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2FF0B6082AAF5257001F5DEE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2FF0B6122AAF5257001F5DEE /* ContentView.swift in Sources */,
+				2FF0B6102AAF5257001F5DEE /* XcodeAppApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		2FF0B6182AAF5258001F5DEE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		2FF0B6192AAF5258001F5DEE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		2FF0B61B2AAF5258001F5DEE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"XcodeApp/Preview Content\"";
+				DEVELOPMENT_TEAM = 6WN9W2ZWNW;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = uk.org.healthdatainsight.interns.app.XcodeApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2FF0B61C2AAF5258001F5DEE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"XcodeApp/Preview Content\"";
+				DEVELOPMENT_TEAM = 6WN9W2ZWNW;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = uk.org.healthdatainsight.interns.app.XcodeApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2FF0B6072AAF5257001F5DEE /* Build configuration list for PBXProject "XcodeApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2FF0B6182AAF5258001F5DEE /* Debug */,
+				2FF0B6192AAF5258001F5DEE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2FF0B61A2AAF5258001F5DEE /* Build configuration list for PBXNativeTarget "XcodeApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2FF0B61B2AAF5258001F5DEE /* Debug */,
+				2FF0B61C2AAF5258001F5DEE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 2FF0B6042AAF5257001F5DEE /* Project object */;
+}


### PR DESCRIPTION
## What?

I've added support for Xcode projects during `way_of_working init linter`. It adds a SwiftLint build phase to the Xcode project.

## Why?

If the stick is that you must use SwiftLint for projects written in Swift, the carrot should be that we automatically add the build step to an Xcode project.

## How?

This adds to the linter initialiser, looking for a `project.pbxproj` file within a `*.xcodeproj` package. If found, it injects the PBXResourcesBuildPhase and build phase section.

## Testing?

A real project file was created and added to the test resources to automatically check that the injection worked.

## Anything Else?

No