### PR TITLE
Ignore tasks.rb from Zeitwerk autoloader

### DIFF
--- a/lib/way_of_working.rb
+++ b/lib/way_of_working.rb
@@ -8,6 +8,10 @@ require 'zeitwerk'
 require 'way_of_working/readme_badge'
 
 loader = Zeitwerk::Loader.for_gem
+# tasks.rb is a rake-task entrypoint, not a constant definition — exclude it
+# from Zeitwerk's file-to-constant expectations so downstream apps can
+# `require 'way_of_working/tasks'` from their Rakefile.
+loader.ignore(File.expand_path('way_of_working/tasks.rb', __dir__))
 loader.setup
 
 # This is the namespace for everything associated with the Way of Working


### PR DESCRIPTION
## What?

`way_of_working/tasks.rb` is a rake-task entrypoint (it requires some rake files and registers `RuboCop::RakeTask.new`), not a constant definition. Since `Zeitwerk::Loader.for_gem` walks `lib/` and demands every `.rb` file declare a matching constant, any downstream app that `require 'way_of_working/tasks'` from its `Rakefile` hits:

```
Zeitwerk::NameError: expected file .../lib/way_of_working/tasks.rb to define constant WayOfWorking::Tasks, but didn't
```

This PR excludes `tasks.rb` from the loader so it stays a plain require-able side-effect script, unblocking `bin/rails` boot for consumers.

## Why?

The suggested consumer integration — `require 'way_of_working/tasks'` in `Rakefile` — is currently broken on Rails apps. Any `bin/rails test`, `bin/rails console`, or `bin/rake` invocation that causes the `Rakefile` to load raises during boot. Consumers have no good workaround short of removing the `require` (and losing the rake tasks) or monkey-patching Zeitwerk.

## How?

Four lines in `lib/way_of_working.rb` — after `Zeitwerk::Loader.for_gem` but before `loader.setup`, call `loader.ignore(...)` on the absolute path of `lib/way_of_working/tasks.rb`. Zeitwerk then skips it when walking the lib root, so the file behaves as a normal Ruby script again.

The alternative — moving the file out of `lib/way_of_working/` — would be a breaking change for every downstream `require 'way_of_working/tasks'`. `loader.ignore` is non-breaking.

## Testing?

Repro + verification in a real downstream app (Rails 8.1.3, Ruby 3.4.7):

1. Add `require 'way_of_working/tasks' if Rails.env.local?` to `Rakefile`.
2. `bin/rails test` → `Zeitwerk::NameError` on `main`.
3. Point `Gemfile` at this branch, `bundle install`, `bin/rails test` → boots past the Rakefile (next failure is unrelated: a missing `config/database.yml`).

No gem-level unit tests added — the change is purely loader configuration and is exercised by any consumer that requires `way_of_working/tasks`.

## Anything Else?

Happy to add a brief note to the README pointing consumers at `require 'way_of_working/tasks'` now that it actually works, in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)