### PR TITLE
Bundle inclusive language, decision records and changelog as opt-in built-in features

### DIFF
--- a/.github/linters/rubocop_defaults.yml
+++ b/.github/linters/rubocop_defaults.yml
@@ -7,7 +7,7 @@ inherit_mode:
     - Exclude
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 # Ignore rules related to templated files
 Layout/EmptyLines:

--- a/.github/workflows/inclusive-language.yml
+++ b/.github/workflows/inclusive-language.yml
@@ -9,7 +9,7 @@ jobs:
     name: Inclusive Language Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node via mise
         uses: jdx/mise-action@v2
       - name: Run alex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,27 +1,44 @@
 ---
-name: Rake Test
+name: Ruby Tests
 
-on: push  # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+
+  pull_request:
 
 permissions: read-all
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
         ruby:
+          - '3.2'
           - '3.3'
           - '3.4'
           - '4.0'
 
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - name: Set up Ruby via mise
+        uses: jdx/mise-action@v2
         with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
+          tool_versions: |
+            ruby ${{ matrix.ruby }}
+      - name: Cache bundler
+        uses: actions/cache@v4
+        with:
+          path: vendor/bundle
+          key: bundle-${{ runner.os }}-${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            bundle-${{ runner.os }}-${{ matrix.ruby }}-
+      - name: Install gems
+        run: |
+          bundle config set --local path vendor/bundle
+          bundle install --jobs 4
       - name: Run the default task
         run: bundle exec rake

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,5 @@
 [settings]
 idiomatic_version_file_enable_tools = ['ruby']
+
+[tools]
+node = "lts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Bundled the Inclusive Language (alex) feature into this gem. It is opt in and replaces the separate `way_of_working-inclusive_language-alex` plugin gem.
+
 ## [2.0.1] - 2025-01-17
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Bundled the Changelog (Keep a Changelog) feature into this gem. It is opt in and replaces the separate `way_of_working-changelog-keepachangelog` plugin gem.
 - Bundled the Decision Records (MADR) feature into this gem. It is opt in and replaces the separate `way_of_working-decision_record-madr` plugin gem.
 - Bundled the Inclusive Language (alex) feature into this gem. It is opt in and replaces the separate `way_of_working-inclusive_language-alex` plugin gem.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Bundled the Decision Records (MADR) feature into this gem. It is opt in and replaces the separate `way_of_working-decision_record-madr` plugin gem.
 - Bundled the Inclusive Language (alex) feature into this gem. It is opt in and replaces the separate `way_of_working-inclusive_language-alex` plugin gem.
 
 ## [2.0.1] - 2025-01-17

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Some features are bundled with this gem rather than shipped as separate plugins.
 
 #### Changelog
 
-Keeping a curated, human-readable changelog makes it easy for users and contributors to see what has changed between releases without trawling through the commit history.
+Keeping a curated, human-readable changelog helps users and contributors quickly see what has changed between releases without trawling through the commit history.
 
 This feature uses [Keep a Changelog v1.1][keepachangelog v1.1] to generate a `CHANGELOG.md`, seeding it with sections derived from your git tags and commit messages where possible. Enable it by requiring it:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Below is a list of plugins that have been implemented so far:
 | Changelog             | [changelog-keepachangelog]             | Implements [keepachangelog v1.1]                                                       |
 | Code Linting          | [code_linting-hdi]                     | Implements a combination of [MegaLinter] and [RuboCop] built on NDRS standards         |
 | Code of Conduct       | [code_of_conduct-contributor_covenant] | Implements [Contributor Covenant v2.1]                                                 |
-| Decision Records      | [decision_record-madr]                 | Implements [MADR v3]                                                                   |
+| Decision Records      | Built-in (decision_record/madr)        | Implements [MADR v3] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Inclusive Language    | Built-in (inclusive_language/alex)     | Implements [alex] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Pull Request Template | [pull_request_template-hdi]            | Implements a bespoke PR template                                                       |
 | Versioning            | [versioning-semver]                    | Implements [Semantic Versioning v2.0.0]                                                |
@@ -63,6 +63,26 @@ You will need to provide the Code of Conduct `[CONTACT METHOD]`, usually an emai
 ### Built-in Features
 
 Some features are bundled with this gem rather than shipped as separate plugins. These built-in features are **opt in**: enable one by requiring it wherever you load Way of Working — for example in your organisation's Way of Working gem, or in your project's `Rakefile`.
+
+#### Decision Records
+
+Recording the context and reasoning behind significant decisions helps current and future contributors understand why a project is the way it is, avoids relitigating settled questions, and onboards newcomers faster.
+
+This feature uses [Markdown Any Decision Records (MADR)][MADR v3] to capture decisions as version-controlled Markdown alongside your code. Enable it by requiring it:
+
+```ruby
+require 'way_of_working/decision_record/madr'
+```
+
+Once required, two subcommands become available:
+
+```bash
+# Add the decision records index, template and first record to your project
+way_of_working init decision_record
+
+# Create a new decision record
+way_of_working new decision_record "Title of the decision"
+```
 
 #### Inclusive Language
 
@@ -124,6 +144,5 @@ Everyone interacting in the WayOfWorking project's codebases, issue trackers, ch
 [changelog-keepachangelog]: https://github.com/HealthDataInsight/way_of_working-changelog-keepachangelog
 [code_linting-hdi]: https://github.com/HealthDataInsight/way_of_working-code_linting-hdi
 [code_of_conduct-contributor_covenant]: https://github.com/HealthDataInsight/way_of_working-code_of_conduct-contributor_covenant
-[decision_record-madr]: https://github.com/HealthDataInsight/way_of_working-decision_record-madr
 [pull_request_template-hdi]: https://github.com/HealthDataInsight/way_of_working-pull_request_template-hdi
 [versioning-semver]: https://github.com/HealthDataInsight/way_of_working-versioning-semver

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Below is a list of plugins that have been implemented so far:
 | Feature               | Plugin                                 | Description                                                                            |
 | --------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------|
 | Audit                 | [audit-github]                         | A framework for rules to check for incorrect content and configuration of GitHub repos |
-| Changelog             | [changelog-keepachangelog]             | Implements [keepachangelog v1.1]                                                       |
+| Changelog             | Built-in (changelog/keepachangelog)    | Implements [keepachangelog v1.1] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Code Linting          | [code_linting-hdi]                     | Implements a combination of [MegaLinter] and [RuboCop] built on NDRS standards         |
 | Code of Conduct       | [code_of_conduct-contributor_covenant] | Implements [Contributor Covenant v2.1]                                                 |
 | Decision Records      | Built-in (decision_record/madr)        | Implements [MADR v3] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
@@ -63,6 +63,23 @@ You will need to provide the Code of Conduct `[CONTACT METHOD]`, usually an emai
 ### Built-in Features
 
 Some features are bundled with this gem rather than shipped as separate plugins. These built-in features are **opt in**: enable one by requiring it wherever you load Way of Working — for example in your organisation's Way of Working gem, or in your project's `Rakefile`.
+
+#### Changelog
+
+Keeping a curated, human-readable changelog makes it easy for users and contributors to see what has changed between releases without trawling through the commit history.
+
+This feature uses [Keep a Changelog v1.1][keepachangelog v1.1] to generate a `CHANGELOG.md`, seeding it with sections derived from your git tags and commit messages where possible. Enable it by requiring it:
+
+```ruby
+require 'way_of_working/changelog/keepachangelog'
+```
+
+Once required, a subcommand becomes available:
+
+```bash
+# Add a Keep a Changelog CHANGELOG.md and documentation to your project
+way_of_working init changelog
+```
 
 #### Decision Records
 
@@ -141,7 +158,6 @@ Everyone interacting in the WayOfWorking project's codebases, issue trackers, ch
 [RuboCop]: https://rubocop.org
 [Semantic Versioning v2.0.0]: https://semver.org/spec/v2.0.0.html
 [audit-github]: https://github.com/HealthDataInsight/way_of_working-audit-github
-[changelog-keepachangelog]: https://github.com/HealthDataInsight/way_of_working-changelog-keepachangelog
 [code_linting-hdi]: https://github.com/HealthDataInsight/way_of_working-code_linting-hdi
 [code_of_conduct-contributor_covenant]: https://github.com/HealthDataInsight/way_of_working-code_of_conduct-contributor_covenant
 [pull_request_template-hdi]: https://github.com/HealthDataInsight/way_of_working-pull_request_template-hdi

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ Below is a list of plugins that have been implemented so far:
 | Code Linting          | [code_linting-hdi]                     | Implements a combination of [MegaLinter] and [RuboCop] built on NDRS standards         |
 | Code of Conduct       | [code_of_conduct-contributor_covenant] | Implements [Contributor Covenant v2.1]                                                 |
 | Decision Records      | [decision_record-madr]                 | Implements [MADR v3]                                                                   |
-| Inclusive Language    | [inclusive_language-alex]              | Implements [alex]                                                                      |
+| Inclusive Language    | Built-in (inclusive_language/alex)     | Implements [alex] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Pull Request Template | [pull_request_template-hdi]            | Implements a bespoke PR template                                                       |
 | Versioning            | [versioning-semver]                    | Implements [Semantic Versioning v2.0.0]                                                |
+
+Some features are **Built-in** — they ship inside this gem and are enabled by requiring them (see [Built-in Features](#built-in-features)); the others are separate plugin gems that you add as dependencies.
 
 ## Installation
 
@@ -57,6 +59,30 @@ way_of_working init all --contact-method [CONTACT METHOD]
 ```
 
 You will need to provide the Code of Conduct `[CONTACT METHOD]`, usually an email address, for community leaders to receive reports of unacceptable behavior.
+
+### Built-in Features
+
+Some features are bundled with this gem rather than shipped as separate plugins. These built-in features are **opt in**: enable one by requiring it wherever you load Way of Working — for example in your organisation's Way of Working gem, or in your project's `Rakefile`.
+
+#### Inclusive Language
+
+Using insensitive and inconsiderate language can cause harm to others, create barriers to communication, and damage relationships. It can make people feel excluded, disrespected, and devalued, and may perpetuate negative stereotypes and biases.
+
+This feature uses [alex] for automated testing of inclusive language, both at the command line and as a GitHub workflow. Enable it by requiring it:
+
+```ruby
+require 'way_of_working/inclusive_language/alex'
+```
+
+Once required, two subcommands become available:
+
+```bash
+# Add the alex config, .alexignore, GitHub Action and documentation to your project
+way_of_working init inclusive_language
+
+# Run the inclusive language checks
+way_of_working exec inclusive_language
+```
 
 ### Help
 
@@ -99,6 +125,5 @@ Everyone interacting in the WayOfWorking project's codebases, issue trackers, ch
 [code_linting-hdi]: https://github.com/HealthDataInsight/way_of_working-code_linting-hdi
 [code_of_conduct-contributor_covenant]: https://github.com/HealthDataInsight/way_of_working-code_of_conduct-contributor_covenant
 [decision_record-madr]: https://github.com/HealthDataInsight/way_of_working-decision_record-madr
-[inclusive_language-alex]: https://github.com/HealthDataInsight/way_of_working-inclusive_language-alex
 [pull_request_template-hdi]: https://github.com/HealthDataInsight/way_of_working-pull_request_template-hdi
 [versioning-semver]: https://github.com/HealthDataInsight/way_of_working-versioning-semver

--- a/lib/way_of_working.rb
+++ b/lib/way_of_working.rb
@@ -16,8 +16,9 @@ loader.ignore(File.expand_path('way_of_working/tasks.rb', __dir__))
 # way_of_working-audit-github plugin is present — see readme_badge.rb) and
 # requires a constant from that plugin at the top of the file. Exclude it
 # from Zeitwerk's eager-load walk so its absence doesn't break the loader.
-loader.ignore(File.expand_path('way_of_working/readme_badge/github_audit_rule.rb', __dir__))
+loader.ignore(File.expand_path('way_of_working/decision_record/madr/github_audit_rule.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/inclusive_language/alex/github_audit_rule.rb', __dir__))
+loader.ignore(File.expand_path('way_of_working/readme_badge/github_audit_rule.rb', __dir__))
 loader.setup
 
 # This is the namespace for everything associated with the Way of Working

--- a/lib/way_of_working.rb
+++ b/lib/way_of_working.rb
@@ -16,6 +16,7 @@ loader.ignore(File.expand_path('way_of_working/tasks.rb', __dir__))
 # way_of_working-audit-github plugin is present — see readme_badge.rb) and
 # requires a constant from that plugin at the top of the file. Exclude it
 # from Zeitwerk's eager-load walk so its absence doesn't break the loader.
+loader.ignore(File.expand_path('way_of_working/changelog/keepachangelog/github_audit_rule.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/decision_record/madr/github_audit_rule.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/inclusive_language/alex/github_audit_rule.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/readme_badge/github_audit_rule.rb', __dir__))

--- a/lib/way_of_working.rb
+++ b/lib/way_of_working.rb
@@ -17,6 +17,7 @@ loader.ignore(File.expand_path('way_of_working/tasks.rb', __dir__))
 # requires a constant from that plugin at the top of the file. Exclude it
 # from Zeitwerk's eager-load walk so its absence doesn't break the loader.
 loader.ignore(File.expand_path('way_of_working/readme_badge/github_audit_rule.rb', __dir__))
+loader.ignore(File.expand_path('way_of_working/inclusive_language/alex/github_audit_rule.rb', __dir__))
 loader.setup
 
 # This is the namespace for everything associated with the Way of Working

--- a/lib/way_of_working/changelog/keepachangelog.rb
+++ b/lib/way_of_working/changelog/keepachangelog.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'keepachangelog/generators/init'
+
+# If way_of_working-audit-github is used we can add a rule
+begin
+  require 'way_of_working/audit/github/rules/registry'
+  require_relative 'keepachangelog/github_audit_rule'
+rescue LoadError # rubocop:disable Lint/SuppressedException
+end
+
+module WayOfWorking
+  module Changelog
+    module Keepachangelog
+      class Error < StandardError; end
+    end
+  end
+
+  module SubCommands
+    # This reopens the "way_of_working init" sub command
+    class Init
+      register(Changelog::Keepachangelog::Generators::Init, 'changelog', 'changelog',
+               <<~LONGDESC)
+                 Description:
+                     This adds the Keep a Changelog v1.1 changelog to the project
+
+                 Example:
+                     way_of_working init changelog
+
+                     This will create:
+                     CHANGELOG.md
+               LONGDESC
+    end
+  end
+end

--- a/lib/way_of_working/changelog/keepachangelog/generators/init.rb
+++ b/lib/way_of_working/changelog/keepachangelog/generators/init.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'way_of_working/git/repo_reader'
+
+module WayOfWorking
+  module Changelog
+    module Keepachangelog
+      module Generators
+        # This class generates the CHANGELOG.md file, generating sections based on
+        # git tags and commit messages (where possible).
+        class Init < Thor::Group
+          include Thor::Actions
+
+          source_root WayOfWorking.root.join('lib', 'way_of_working', 'changelog', 'keepachangelog', 'templates')
+
+          HEADER_TEXT = <<~TEXT
+            # Changelog
+
+            All notable changes to this project will be documented in this file.
+
+            The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+            and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+          TEXT
+
+          def add_changelog_to_project
+            create_file 'CHANGELOG.md' do
+              HEADER_TEXT + releases + footer
+            end
+          end
+
+          def copy_way_of_working_documentation
+            copy_file 'docs/way_of_working/changelog.md'
+          end
+
+          private
+
+          def releases
+            text = "## [Unreleased]\n\n"
+            text += added_change_text(:minor)
+            text += deprecated_removed_fixed_security_text(:minor)
+
+            summary_tags.each do |summary_tag|
+              text += "## [#{summary_tag.version}] - " \
+                      "#{summary_tag.commit_date.strftime('%Y-%m-%d')}\n\n"
+
+              text += added_change_text(summary_tag.change_type)
+              text += deprecated_removed_fixed_security_text(summary_tag.change_type)
+            end
+
+            text
+          end
+
+          def added_change_text(tag_change_type)
+            return '' if tag_change_type == :patch
+
+            change_text('Added', 'Detail new feature(s) here', true) +
+              change_text('Change', 'Detail change(s) in existing functionality here',
+                          tag_change_type == :major)
+          end
+
+          def deprecated_removed_fixed_security_text(tag_change_type)
+            change_text('Deprecated', 'Detail soon-to-be removed features here') +
+              change_text('Removed', 'Detail removed features here', tag_change_type == :major) +
+              change_text('Fixed', 'Detail any bug fixes here', true) +
+              change_text('Security', 'Detail fixes to vulnerabilities here')
+          end
+
+          # This method adds all of the reference style markdown links
+          def footer
+            return '' if summary_tags.empty?
+
+            previous_tag = nil
+            footer_text = ''
+            summary_tags.each do |summary_tag|
+              footer_text += if previous_tag
+                               release_link(summary_tag.name, previous_tag.name, previous_tag.version)
+                             else
+                               release_link(summary_tag.name, 'HEAD', 'Unreleased')
+                             end
+
+              previous_tag = summary_tag
+            end
+
+            footer_text += "[#{previous_tag.version}]: #{url}/releases/tag/#{previous_tag.name}\n"
+
+            footer_text
+          end
+
+          def release_link(start_tag, end_tag, version)
+            "[#{version}]: #{url}/compare/#{start_tag}...#{end_tag}\n"
+          end
+
+          def change_text(type, description, likely = false)
+            text = "### #{type}\n\n- TODO: #{description}"
+            text += ' (if any)' unless likely
+            text += "\n\n"
+            text
+          end
+
+          def repo_reader
+            @repo_reader ||= ::WayOfWorking::Git::RepoReader.new(::Git.open('.'))
+          end
+
+          def summary_tags
+            @summary_tags ||= repo_reader.summary_tags.reverse
+          rescue ArgumentError
+            []
+          end
+
+          def url
+            @url ||= repo_reader.likely_upstream_remote_url
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/changelog/keepachangelog/github_audit_rule.rb
+++ b/lib/way_of_working/changelog/keepachangelog/github_audit_rule.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'way_of_working/audit/github/rules/base'
+
+module WayOfWorking
+  module Changelog
+    # The namespace for this plugin
+    module Keepachangelog
+      # This rule checks for the Pull Request template.
+      class GithubAuditRule < ::WayOfWorking::Audit::Github::Rules::Base
+        def validate
+          @errors << 'No Keep a Changelog CHANGELOG.md found' unless keep_a_changelog_found?
+        end
+
+        private
+
+        def keep_a_changelog_found?
+          response = @client.contents(@repo_name, path: 'CHANGELOG.md')
+          decoded_content = Base64.decode64(response.content)
+
+          decoded_content.include?('Keep a Changelog')
+        rescue Octokit::NotFound
+          false
+        end
+      end
+
+      ::WayOfWorking::Audit::Github::Rules::Registry.register(
+        GithubAuditRule, 'Keep a Changelog CHANGELOG.md'
+      )
+    end
+  end
+end

--- a/lib/way_of_working/changelog/keepachangelog/templates/docs/way_of_working/changelog.md
+++ b/lib/way_of_working/changelog/keepachangelog/templates/docs/way_of_working/changelog.md
@@ -1,0 +1,73 @@
+---
+layout: page
+status: REQUIRED
+enforcement: manual
+---
+
+# Changelog
+
+![Keep a Changelog v1.1.0 badge][changelog-badge]
+
+## Purpose
+
+Maintain a human-readable project history that documents all notable changes between versions in plain English.
+
+## Scope
+
+All projects must maintain a changelog using [Keep a Changelog v1.1.0][keep-a-changelog] format.
+
+## Requirements
+
+- Human-written plain English summaries (not commit log dumps)
+- Entry for every version
+- Latest version listed first
+- Release date displayed for each version
+- Changes grouped by type: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
+- Versions and sections must be linkable
+- Follow [Semantic Versioning][semver]
+- Update changelog within Pull Requests, not at release time
+
+## Setup
+
+Initialise a changelog for your project:
+
+```bash
+way_of_working init changelog
+```
+
+For git-based projects with existing releases, this scaffolds sections based on semantic version tags.
+
+## Usage
+
+1. Update the `Unreleased` section in each Pull Request
+2. Group changes under appropriate headings
+3. Write clear, user-focused descriptions
+4. Move `Unreleased` changes to a version section at release
+5. Use scaffolded commit links to document historical changes
+
+## Enforcement
+
+- Changelog updates required in Pull Request reviews
+- No automatic commit log dumps permitted
+
+## Examples
+
+```markdown
+## [1.2.0] - 2025-10-22
+
+### Added
+- User authentication via OAuth2
+- Export data to CSV functionality
+
+### Fixed
+- Memory leak in background job processor
+```
+
+## Resources
+
+- [Keep a Changelog][keep-a-changelog]
+- [Semantic Versioning][semver]
+
+[changelog-badge]: https://img.shields.io/badge/changelog-Keep%20a%20Changelog%20v1.1.0-%23E05735
+[keep-a-changelog]: https://keepachangelog.com/en/1.1.0/
+[semver]: https://semver.org

--- a/lib/way_of_working/decision_record/madr.rb
+++ b/lib/way_of_working/decision_record/madr.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative 'madr/generators/init'
+require_relative 'madr/generators/new'
+
+# If way_of_working-audit-github is used we can add a rule
+begin
+  require 'way_of_working/audit/github/rules/registry'
+  require_relative 'madr/github_audit_rule'
+rescue LoadError # rubocop:disable Lint/SuppressedException
+end
+
+module WayOfWorking
+  module DecisionRecord
+    module Madr
+      class Error < StandardError; end
+    end
+  end
+
+  module SubCommands
+    # This reopens the "way_of_working init" sub command
+    class Init
+      register(DecisionRecord::Madr::Generators::Init, 'decision_record', 'decision_record',
+               <<~LONGDESC)
+                 Description:
+                     This generator adds Markdown Any Decision Records (MADR) to your project
+
+                 Example:
+                     way_of_working init decision_record
+
+                     This will create:
+                         docs/decisions/README.md
+                         docs/decisions/adr-template.md
+                         docs/decisions/0000-use-markdown-any-decision-records.md
+               LONGDESC
+    end
+
+    # This reopens the "way_of_working new" sub command
+    class New
+      register(DecisionRecord::Madr::Generators::New, 'decision_record', 'decision_record [NAME]',
+               <<~LONGDESC)
+                 Description:
+                     This generator adds a new decision record to your project
+
+                 Example:
+                     way_of_working new decision_record "Title of the decision"
+
+                     This will create:
+                         docs/decisions/NNNN-title-of-the-decision.md
+               LONGDESC
+    end
+  end
+end

--- a/lib/way_of_working/decision_record/madr/generators/init.rb
+++ b/lib/way_of_working/decision_record/madr/generators/init.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module WayOfWorking
+  module DecisionRecord
+    module Madr
+      module Generators
+        # This generator add the MADR files to the doc/decisions folder
+        class Init < Thor::Group
+          include Thor::Actions
+
+          source_root WayOfWorking.root.join('lib', 'way_of_working', 'decision_record', 'madr', 'templates')
+
+          def copy_decision_record_issue_template
+            copy_file '.github/ISSUE_TEMPLATE/decision-record.md'
+          end
+
+          # Templates are from https://github.com/adr/madr/tree/3.0.0/template
+          def create_decision_record_files
+            copy_file 'docs/decisions/README.md'
+
+            # from https://raw.githubusercontent.com/adr/madr/3.0.0/template/adr-template.md
+            @decision_date = '{YYYY-MM-DD when the decision was last updated}'
+            @index = '{index}'
+            @title = '{short title of solved problem and solution}'
+            template 'docs/decisions/adr-template.md'
+
+            copy_file 'docs/decisions/0000-use-markdown-any-decision-records.md'
+          end
+
+          def copy_index_file
+            copy_file 'docs/decisions/index.md'
+          end
+
+          def copy_way_of_working_file
+            copy_file 'docs/way_of_working/decision-records.md'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/decision_record/madr/generators/new.rb
+++ b/lib/way_of_working/decision_record/madr/generators/new.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'date'
+
+module WayOfWorking
+  module DecisionRecord
+    module Madr
+      module Generators
+        # This generator add a new MADR decision record to the doc/decisions folder
+        class New < Thor::Group
+          argument :name, type: :string, required: true, desc: 'The title of the decision record'
+
+          include Thor::Actions
+
+          source_root WayOfWorking.root.join('lib', 'way_of_working', 'decision_record', 'madr', 'templates')
+
+          def create_decision_record_file
+            case behavior
+            when :invoke
+              invoke_decision_record_file
+            when :revoke
+              revoke_decision_record_file
+            end
+          end
+
+          private
+
+          def invoke_decision_record_file
+            @decision_date = Date.today.strftime('%Y-%m-%d')
+            @index = next_decision_number.to_i
+            @title = name
+
+            # from https://raw.githubusercontent.com/adr/madr/3.0.0/template/adr-template.md
+            template 'docs/decisions/adr-template.md',
+                     "docs/decisions/#{next_decision_number}-#{dashed_name}.md"
+          end
+
+          def revoke_decision_record_file
+            matching_files = Dir.glob("[0-9][0-9][0-9][0-9]-#{dashed_name}.md",
+                                      base: File.join(destination_root, 'docs/decisions'))
+            raise "No matching decision record for '#{dashed_name}'" if matching_files.empty?
+
+            # based on Thor's remove_file
+            path = File.expand_path("docs/decisions/#{matching_files.first}", destination_root)
+
+            say_status :remove, relative_to_original_destination_root(path)
+            return unless !options[:pretend] && (File.exist?(path) || File.symlink?(path))
+
+            require 'fileutils'
+            ::FileUtils.rm_rf(path)
+          end
+
+          def next_decision_number
+            existing_decisions = Dir.glob('[0-9][0-9][0-9][0-9]-*.md',
+                                          base: File.join(destination_root, 'docs/decisions'))
+            last_number = existing_decisions.map do |filename|
+              filename.match(/\A(\d{4})-/)[1].to_i
+            end.max || -1
+            format('%04d', last_number + 1)
+          end
+
+          def dashed_name
+            name.downcase.gsub(/[\s_()]/, '-').gsub(/-+/, '-')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/decision_record/madr/github_audit_rule.rb
+++ b/lib/way_of_working/decision_record/madr/github_audit_rule.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'way_of_working/audit/github/rules/base'
+
+module WayOfWorking
+  module DecisionRecord
+    # The namespace for plugin
+    module Madr
+      # This rule checks for the MADR Decision Record template.
+      class GithubAuditRule < ::WayOfWorking::Audit::Github::Rules::Base
+        ADR_TEMPLATE_PATH = 'docs/decisions/adr-template.md'
+        DECISION_ZERO_PATH = 'docs/decisions/0000-use-markdown-any-decision-records.md'
+        WOW_DOCUMENTATION_PATH = 'docs/way_of_working/decision-records.md'
+
+        source_root WayOfWorking.root.join('lib', 'way_of_working', 'decision_record', 'madr', 'templates')
+
+        def validate
+          @errors << 'No MADR Decision Record template found' unless repo_file_contains?(
+            ADR_TEMPLATE_PATH, '## Context and Problem Statement'
+          )
+
+          unless repo_file_contains_source_file?(WOW_DOCUMENTATION_PATH)
+            @errors << 'Stale or missing documentation for using MADR Decision Records'
+          end
+
+          return if repo_file_contains_source_file?(DECISION_ZERO_PATH)
+
+          @errors << 'No 0000-use-markdown-any-decision-records.md Decision Record found'
+        end
+
+        private
+
+        def repo_file_contains_source_file?(path)
+          repo_file_contains?(path, File.read(self.class.source_root.join(path)))
+        end
+
+        def repo_file_contains?(path, text)
+          remote_content = repo_file_contents(path)
+          return false if remote_content.nil?
+
+          remote_content.include?(text)
+        end
+      end
+
+      ::WayOfWorking::Audit::Github::Rules::Registry.register(
+        GithubAuditRule, 'MADR Decision Records'
+      )
+    end
+  end
+end

--- a/lib/way_of_working/decision_record/madr/templates/.github/ISSUE_TEMPLATE/decision-record.md
+++ b/lib/way_of_working/decision_record/madr/templates/.github/ISSUE_TEMPLATE/decision-record.md
@@ -1,0 +1,26 @@
+---
+name: Decision Record
+about: Create a ticket to discuss or propose a new decision record
+title: ''
+labels: decision record
+assignees: ''
+
+---
+## Context and Problem Statement
+
+{Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story.
+ You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Decision Drivers
+
+* {decision driver 1, e.g., a force, facing concern, …}
+* {decision driver 2, e.g., a force, facing concern, …}
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* … <!-- numbers of options can vary -->

--- a/lib/way_of_working/decision_record/madr/templates/docs/decisions/0000-use-markdown-any-decision-records.md
+++ b/lib/way_of_working/decision_record/madr/templates/docs/decisions/0000-use-markdown-any-decision-records.md
@@ -1,0 +1,30 @@
+---
+nav_order: 0
+parent: Decision Records
+---
+# Use Markdown Any Decision Records
+
+## Context and Problem Statement
+
+We want to record any decisions made in this project independent whether decisions concern the architecture ("architectural decision record"), the code, or other fields.
+Which format and structure should these records follow?
+
+## Considered Options
+
+* [MADR](https://adr.github.io/madr/) 3.0.0 – The Markdown Any Decision Records
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
+* [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) – The Y-Statements
+* Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
+* Formless – No conventions for file format and structure
+
+## Decision Outcome
+
+Chosen option: "MADR 3.0.0", because
+
+* Implicit assumptions should be made explicit.
+  Design documentation is important to enable people understanding the decisions later on.
+  See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
+* MADR allows for structured capturing of any decision.
+* The MADR format is lean and fits our development style.
+* The MADR structure is comprehensible and facilitates usage & maintenance.
+* The MADR project is vivid.

--- a/lib/way_of_working/decision_record/madr/templates/docs/decisions/README.md
+++ b/lib/way_of_working/decision_record/madr/templates/docs/decisions/README.md
@@ -1,0 +1,7 @@
+# Decisions
+
+This directory contains decision records for the project.
+
+For new ADRs, please use [adr-template.md](adr-template.md) as basis.
+More information on MADR is available at <https://adr.github.io/madr/>.
+General information about architectural decision records is available at <https://adr.github.io/>.

--- a/lib/way_of_working/decision_record/madr/templates/docs/decisions/adr-template.md.tt
+++ b/lib/way_of_working/decision_record/madr/templates/docs/decisions/adr-template.md.tt
@@ -1,0 +1,82 @@
+---
+nav_order: <%= @index %>
+parent: Decision Records
+
+# These are optional elements. Feel free to remove any of them.
+status: {proposed | rejected | accepted | deprecated | … | superseded by ADR-0005 <0005-example.md>}
+date: <%= @decision_date %>
+deciders: {list everyone involved in the decision}
+consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
+informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
+---
+# <%= @title %>
+
+## Context and Problem Statement
+
+{Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story.
+ You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Decision Drivers
+
+* {decision driver 1, e.g., a force, facing concern, …}
+* {decision driver 2, e.g., a force, facing concern, …}
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because
+{justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
+
+<!-- This is an optional element. Feel free to remove. -->
+### Consequences
+
+* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+* … <!-- numbers of consequences can vary -->
+
+<!-- This is an optional element. Feel free to remove. -->
+## Validation
+
+{describe how the implementation of/compliance with the ADR is validated. E.g., by a review or an ArchUnit test}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Pros and Cons of the Options
+
+### {title of option 1}
+
+<!-- This is an optional element. Feel free to remove. -->
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+<!-- use "neutral" if the given argument weights neither for good nor bad -->
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* … <!-- numbers of pros and cons can vary -->
+
+### {title of other option}
+
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* …
+
+<!-- This is an optional element. Feel free to remove. -->
+## More Information
+
+{You might want to provide additional evidence/confidence for the decision outcome here and/or
+ document the team agreement on the decision and/or
+ define when and how this decision should be realized and if/when it should be re-visited and/or
+ how the decision is validated.
+ Links to other decisions and resources might appear here as well.}

--- a/lib/way_of_working/decision_record/madr/templates/docs/decisions/index.md
+++ b/lib/way_of_working/decision_record/madr/templates/docs/decisions/index.md
@@ -1,0 +1,48 @@
+---
+has_children: true
+---
+# Decision Records
+
+We use [Markdown Any Decision Records (MADR)](https://adr.github.io/madr/) version 3.0.0.
+
+In general, projects will follow the organisation's way of working and so decisions captured within individual projects will generally cover decisions that:
+
+- are not already covered in the Way of Working
+- are covered in the Way of Working, but have specific implementation details which need to be captured
+- diverge from the guidance in the Way of Working
+
+## Create a new decision record
+
+### Manual approach
+
+1. Copy `docs/decisions/adr-template.md` to `docs/decisions/NNNN-title-with-dashes.md`, where `NNNN` indicates the next number in sequence.
+2. Edit `NNNN-title-with-dashes.md`.
+
+Note you can also use [other patterns for the directory format](https://github.com/joelparkerhenderson/architecture_decision_record#adr-file-name-conventions).
+As a consequence, some existing tooling might not be applicable.
+
+The filenames are following the pattern `NNNN-title-with-dashes.md`, where
+
+- `NNNN` is a consecutive number and we assume that there won't be more than 9,999 ADRs in one repository.
+- the title is stored using dashes and lowercase, because [adr-tools] also does that.
+- the suffix is `.md`, because it is a [Markdown](https://github.github.com/gfm/) file.
+
+Decisions are placed in the subfolder `decisions/` to keep them close to the documentation but also separate the decisions from other documentation.
+
+### Automatic approach
+
+To create a new decision record, run:
+
+```bash
+way_of_working new decision_record [NAME]
+```
+
+Where `[NAME]` is the title of your decision record, for example:
+
+```bash
+way_of_working new decision_record "Use Markdown Any Decision Records"
+```
+
+## Project decision records
+
+Decision records for this project are listed below.

--- a/lib/way_of_working/decision_record/madr/templates/docs/way_of_working/decision-records.md
+++ b/lib/way_of_working/decision_record/madr/templates/docs/way_of_working/decision-records.md
@@ -1,0 +1,195 @@
+---
+layout: page
+status: REQUIRED
+enforcement: manual
+---
+# Decision Records
+
+## Purpose
+
+We use [Markdown Any Decision Records (MADR)][madr] v3.0.0 to capture project decisions that:
+
+- aren't covered in the [Way of Working][wow]
+- need project-specific implementation details
+- diverge from Way of Working guidance
+
+{: .note }
+Proposing and reviewing decisions requires familiarity with [GitHub pull requests][gh-pr].
+
+## Scope
+
+Applies to decisions about:
+
+- **Architecture**: System design, technology stack, frameworks
+- **Process**: Development workflows, deployment, testing
+- **Code standards**: Patterns, conventions, library usage
+- **Dependencies**: Adding/removing major libraries or services
+- **Data**: Schema changes, migration strategies
+
+**Create ADR when:**
+
+- Impact spans multiple components or teams
+- Long-term consequences or significant cost/risk
+- Multiple viable alternatives exist
+
+**Don't create ADR for:**
+
+- Already covered by Way of Working
+- Tactical implementation details (use code comments)
+- Temporary workarounds or clear-cut choices
+
+## Requirements
+
+**File naming:** `NNNN-title-with-dashes.md`
+
+- `NNNN` = consecutive four-digit number (0001, 0002, etc.)
+- Lowercase title with dashes
+- Located in `docs/decisions/`
+
+**Required content:**
+
+1. Status (proposed, accepted, rejected, deprecated, superseded)
+2. Context and problem statement
+3. Considered options (minimum 2)
+4. Decision outcome with justification
+5. Positive and negative consequences
+
+**Status lifecycle:**
+
+- **proposed** - Under discussion
+- **accepted** - Approved for implementation
+- **rejected** - Decided against
+- **deprecated** - No longer relevant
+- **superseded** - Replaced by newer ADR (link required)
+
+## Setup
+
+```bash
+way_of_working init decision_record
+```
+
+## Usage
+
+### Create a new decision record
+
+```bash
+way_of_working new decision_record "Use Markdown Any Decision Records"
+```
+
+**Propose decision:**
+
+1. Create ADR with status "proposed"
+2. Open PR, tag stakeholders
+3. Discuss in PR comments
+4. Update to "accepted" once consensus reached
+5. Merge PR
+
+**Supersede existing ADR:**
+
+1. Create new ADR
+2. Update old ADR status to "superseded by [0XXX-new-title.md](0XXX-new-title.md)"
+3. Explain what changed in new ADR
+
+## Enforcement
+
+**PR Review:**
+
+- All ADRs submitted via PR
+- Maintainer approval required
+- Verify MADR template structure, file naming, location
+- Check minimum 2 options with justification
+
+**Quality checklist:**
+
+- ✅ Multiple alternatives with pros/cons
+- ✅ Clear context and constraints
+- ✅ Explicit trade-offs
+- ❌ Only one option presented
+- ❌ Missing justification or context
+
+**Maintenance:**
+
+- Quarterly review for relevance
+- Update deprecated/superseded status as needed
+
+## Examples
+
+**Database choice:**
+
+```markdown
+# Use PostgreSQL for Primary Database
+
+**Status:** accepted
+**Date:** 2025-10-15
+
+## Context and Problem Statement
+
+Need relational database for user data with complex relationships.
+Constraints: ACID compliance, 100K users/1M records, prefer open-source.
+
+## Considered Options
+
+1. PostgreSQL (self-hosted)
+2. MySQL
+3. RDS PostgreSQL
+
+## Decision Outcome
+
+**Chosen:** PostgreSQL (self-hosted)
+
+**Pros:** Open-source, advanced features (JSON, full-text search), ACID, team experience
+**Cons:** DevOps overhead, manual backup, manual scaling
+
+**Why:** Meets requirements within budget. Cloud-managed exceeds budget by 40%.
+Team expertise mitigates complexity.
+
+**Alternatives rejected:**
+- MySQL: No advantage over PostgreSQL
+- RDS: Cost $200-500/month exceeds budget
+```
+
+**Superseded ADR:**
+
+```markdown
+# Use Jest for Frontend Testing
+
+**Status:** superseded by [0015-use-vitest.md](0015-use-vitest.md)
+**Date:** 2025-01-10 (original), 2025-09-15 (superseded)
+
+**Why superseded:** Vitest now standard for Vite projects,
+better integration and performance.
+```
+
+**Rejected decision:**
+
+```markdown
+# Use GraphQL for API Layer
+
+**Status:** rejected
+**Date:** 2025-03-20
+
+## Decision Outcome
+
+**Chosen:** Continue with REST API
+
+**Why rejected:**
+- Current REST meets all requirements
+- Team lacks GraphQL expertise (4-6 week learning curve)
+- Migration cost: 8 engineer-weeks
+- No client needs GraphQL features
+
+**Reconsider when:** Multiple clients need flexible fetching
+or over-fetching impacts performance.
+```
+
+## Resources
+
+- [MADR Documentation][madr]
+- [GDS Architecture Decisions][gds-way]
+- [Way of Working CLI][wow-cli]
+
+[madr]: https://adr.github.io/madr/
+[wow]: https://github.com/HealthDataInsight/way_of_working
+[gds-way]: https://gds-way.digital.cabinet-office.gov.uk/standards/architecture-decisions.html
+[gh-pr]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
+[wow-cli]: ../cli.md

--- a/lib/way_of_working/inclusive_language/alex.rb
+++ b/lib/way_of_working/inclusive_language/alex.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative 'alex/generators/exec'
+require_relative 'alex/generators/init'
+
+# If way_of_working-audit-github is used we can add a rule
+begin
+  require 'way_of_working/audit/github/rules/registry'
+  require_relative 'alex/github_audit_rule'
+rescue LoadError # rubocop:disable Lint/SuppressedException
+end
+
+module WayOfWorking
+  module InclusiveLanguage
+    module Alex
+      class Error < StandardError; end
+    end
+  end
+
+  module SubCommands
+    # This reopens the "way_of_working exec" (i.e. run) sub command
+    class Exec
+      register(InclusiveLanguage::Alex::Generators::Exec, 'inclusive_language', 'inclusive_language',
+               <<~LONGDESC)
+                 Description:
+                     This runs inclusive language tests on this project
+
+                 Example:
+                     way_of_working exec inclusive_language
+               LONGDESC
+    end
+
+    # This reopens the "way_of_working init" sub command
+    class Init
+      register(InclusiveLanguage::Alex::Generators::Init, 'inclusive_language', 'inclusive_language',
+               <<~LONGDESC)
+                 Description:
+                     Installs alex config file into the project
+
+                 Example:
+                     way_of_working init inclusive_language
+
+                     This will create:
+                         .alexrc
+               LONGDESC
+    end
+  end
+end

--- a/lib/way_of_working/inclusive_language/alex/generators/exec.rb
+++ b/lib/way_of_working/inclusive_language/alex/generators/exec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'thor'
+require 'rainbow'
+
+module WayOfWorking
+  module InclusiveLanguage
+    module Alex
+      module Generators
+        # This generator runs the inclusive language tests
+        class Exec < Thor::Group
+          argument :path, type: :string, required: false, desc: 'Optional path of the file to test'
+
+          desc 'This runs the inclusive language tests on this project'
+
+          def run_first
+            @start_time = Time.now
+
+            say(Rainbow("Limiting tests to #{path}\n").yellow) if path
+          end
+
+          def prep_and_run_alex
+            command = ['npx', 'alex', '--why']
+            # Configure alex to only test a specific file or folder, if defined
+            command << path if path
+
+            say(Rainbow("\nRunning alex...").yellow)
+
+            @alex_ok = run_alex(command)
+          end
+
+          def run_last
+            say(Rainbow("\nTotal time taken: #{(Time.now - @start_time).to_i} seconds").yellow)
+
+            if @alex_ok
+              say(Rainbow("\nInclusive language tests succeeded!").green)
+            else
+              abort(Rainbow("\nInclusive language tests failed!").red)
+            end
+          end
+
+          private
+
+          def run_alex(arguments)
+            system(*arguments)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/inclusive_language/alex/generators/init.rb
+++ b/lib/way_of_working/inclusive_language/alex/generators/init.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'thor'
+
+module WayOfWorking
+  module InclusiveLanguage
+    module Alex
+      module Generators
+        # This generator adds the alexrc file
+        class Init < Thor::Group
+          include Thor::Actions
+
+          source_root WayOfWorking.root.join('lib', 'way_of_working', 'inclusive_language', 'alex', 'templates')
+
+          def copy_inclusive_language_github_workflow_action
+            copy_file '.github/workflows/inclusive-language.yml'
+          end
+
+          def copy_alexignore_file
+            copy_file '.alexignore'
+          end
+
+          def copy_alexrc_file
+            copy_file '.alexrc'
+          end
+
+          def copy_way_of_working_documentation
+            copy_file 'docs/way_of_working/inclusive-language.md'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/inclusive_language/alex/github_audit_rule.rb
+++ b/lib/way_of_working/inclusive_language/alex/github_audit_rule.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'way_of_working/audit/github/rules/base'
+
+module WayOfWorking
+  module InclusiveLanguage
+    # The namespace for plugin
+    module Alex
+      # This rule checks for the Inclusive Language workflow action and README badge.
+      class GithubAuditRule < ::WayOfWorking::Audit::Github::Rules::Base
+        def validate
+          response = @client.workflows(@repo_name)
+
+          unless response.workflows.map(&:name).include?('Inclusive Language')
+            @errors << 'No Inclusive Language GitHub Action'
+          end
+
+          @errors << 'Default branch is named "master"' if @repo.default_branch == 'master'
+
+          @errors << 'No Inclusive Language README Badge' unless inclusive_language_badge?
+        end
+
+        private
+
+        def inclusive_language_badge?
+          readme_content.include?("[![Inclusive Language](https://github.com/#{@repo_name}/actions/workflows/inclusive-language.yml/badge.svg)]")
+        end
+      end
+
+      ::WayOfWorking::Audit::Github::Rules::Registry.register(
+        GithubAuditRule, 'Inclusive Language GitHub Action and README badge'
+      )
+    end
+  end
+end

--- a/lib/way_of_working/inclusive_language/alex/templates/.alexignore
+++ b/lib/way_of_working/inclusive_language/alex/templates/.alexignore
@@ -1,0 +1,2 @@
+/CODE_OF_CONDUCT.md
+/docs/way_of_working/code-of-conduct.md

--- a/lib/way_of_working/inclusive_language/alex/templates/.alexrc
+++ b/lib/way_of_working/inclusive_language/alex/templates/.alexrc
@@ -1,0 +1,3 @@
+{
+  "profanitySureness": 1
+}

--- a/lib/way_of_working/inclusive_language/alex/templates/.github/workflows/inclusive-language.yml
+++ b/lib/way_of_working/inclusive_language/alex/templates/.github/workflows/inclusive-language.yml
@@ -9,9 +9,8 @@ jobs:
     name: Inclusive Language Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
+      - uses: actions/checkout@v6
+      - name: Set up Node via mise
+        uses: jdx/mise-action@v2
       - name: Run alex
         run: npx alex --why

--- a/lib/way_of_working/inclusive_language/alex/templates/.github/workflows/inclusive-language.yml
+++ b/lib/way_of_working/inclusive_language/alex/templates/.github/workflows/inclusive-language.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Node via mise
-        uses: jdx/mise-action@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Run alex
         run: npx alex --why

--- a/lib/way_of_working/inclusive_language/alex/templates/docs/way_of_working/inclusive-language.md
+++ b/lib/way_of_working/inclusive_language/alex/templates/docs/way_of_working/inclusive-language.md
@@ -1,0 +1,28 @@
+---
+layout: page
+---
+
+# Inclusive Language
+
+We have adopted [alex](https://alexjs.com) for automated testing of inclusive language.
+
+Using insensitive and inconsiderate language can cause harm to others, create barriers to communication, and damage relationships. It can make people feel excluded, disrespected, and devalued and may perpetuate negative stereotypes and biases. When we use insensitive or offensive language, we undermine our ability to connect with others and build trust.
+
+Therefore, it is essential to be mindful of the impact of our words and to choose language that is respectful, inclusive, and considerate of others. Doing so can create a more welcoming and inclusive environment for everyone, fostering greater understanding, empathy, and cooperation.
+
+To quote from the alex README:
+
+> No automated tool can replace studying inclusive communication and listening to the lived experiences of others. **An error from alex can be an invitation to learn more**.
+
+{: .important }
+Please take the opportunity to read some of the [further reading](https://github.com/get-alex/alex#further-reading) they reference and click on the links against individual warnings when they appear.
+
+## Usage
+
+To add alex to your project, run the following at the command line:
+
+    way_of_working init inclusive_language
+
+to run alex in your project, run:
+
+    way_of_working exec inclusive_language

--- a/test/way_of_working/audit_github_stub_classes.rb
+++ b/test/way_of_working/audit_github_stub_classes.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# This file provides simplified versions of the classes used by the GitHub audit rule registry
+# It deliberately avoids the Zeitwerk naming convention to ensure it isn't autoloaded.
+module WayOfWorking
+  module Audit
+    module Github
+      module Rules
+        # This is a simplified version of the base class for GitHub audit rules
+        class Base
+          attr_accessor :errors, :name, :rulesets, :warnings
+
+          def initialize(client, name, repo, rulesets)
+            @client = client
+            @name = name
+            @repo = repo
+            @repo_name = repo.full_name
+            @rulesets = rulesets
+            @errors = []
+            @warnings = []
+          end
+
+          def status
+            @status ||= begin
+              validate
+
+              @errors.empty? ? :passed : :failed
+            end
+          end
+
+          def self.tags
+            [:way_of_working]
+          end
+
+          def tags
+            self.class.tags
+          end
+        end
+
+        # This provides the GitHub audit rule factory
+        module Registry
+          class << self
+            attr_accessor :rules
+
+            def register(klass, rule_name)
+              @rules ||= {}
+
+              @rules[rule_name] = klass
+            end
+
+            def unregister(*rule_names)
+              rule_names.each do |rule_name|
+                @rules.delete(rule_name)
+              end
+            end
+
+            def rule(rule_name, client, repo)
+              klass = Registry.rules.fetch(rule_name, Unknown)
+
+              klass.new(client, repo)
+            end
+          end
+        end
+
+        # This is a stub handler for rules that aren't in the registry.
+        class Unknown < Base
+          def initialize(client, repo_name)
+            super
+            raise 'Error: Unknown client'
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/audit_github_stub_classes.rb
+++ b/test/way_of_working/audit_github_stub_classes.rb
@@ -10,12 +10,21 @@ module WayOfWorking
         class Base
           attr_accessor :errors, :name, :rulesets, :warnings
 
-          def initialize(client, name, repo, rulesets)
+          class << self
+            # Stores and return the source root for this class
+            def source_root(path = nil)
+              @source_root = path if path
+              @source_root ||= nil
+            end
+          end
+
+          def initialize(client, name, repo, rulesets, fix = false)
             @client = client
             @name = name
             @repo = repo
             @repo_name = repo.full_name
             @rulesets = rulesets
+            @fix = fix
             @errors = []
             @warnings = []
           end
@@ -34,6 +43,15 @@ module WayOfWorking
 
           def tags
             self.class.tags
+          end
+
+          private
+
+          def repo_file_contents(path)
+            response = @client.contents(@repo_name, path: path)
+            Base64.decode64(response.content).force_encoding('UTF-8')
+          rescue Octokit::NotFound
+            nil
           end
         end
 
@@ -54,17 +72,17 @@ module WayOfWorking
               end
             end
 
-            def rule(rule_name, client, repo)
+            def rule(rule_name, *args)
               klass = Registry.rules.fetch(rule_name, Unknown)
 
-              klass.new(client, repo)
+              klass.new(*args)
             end
           end
         end
 
         # This is a stub handler for rules that aren't in the registry.
         class Unknown < Base
-          def initialize(client, repo_name)
+          def initialize(*args)
             super
             raise 'Error: Unknown client'
           end

--- a/test/way_of_working/changelog/keepachangelog/generators/init_test.rb
+++ b/test/way_of_working/changelog/keepachangelog/generators/init_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'active_support'
+require 'active_support/core_ext'
+
+require 'test_helper'
+
+module WayOfWorking
+  module Changelog
+    module Keepachangelog
+      module Generators
+        # This class tests the Changelog::Init Thor Group (generator)
+        class InitTest < Rails::Generators::TestCase
+          tests WayOfWorking::Changelog::Keepachangelog::Generators::Init
+          destination WayOfWorking.root.join('tmp/generators')
+
+          CHANGELOG_FILENAME = 'CHANGELOG.md'
+
+          setup do
+            prepare_destination
+
+            Init.any_instance.stubs(:url).
+              returns('https://github.com/HealthDataInsight/way_of_working')
+          end
+
+          test 'changelog file is created and revoked' do
+            Init.any_instance.stubs(:summary_tags).returns([
+              ::WayOfWorking::Git::SummaryTag.new('v0.1.0', 10.days.ago),
+              ::WayOfWorking::Git::SummaryTag.new('v1.0.0', 7.days.ago),
+              ::WayOfWorking::Git::SummaryTag.new('v1.0.1', 6.days.ago),
+              ::WayOfWorking::Git::SummaryTag.new('v1.1.0', 4.days.ago),
+              ::WayOfWorking::Git::SummaryTag.new('v2.0.0', 1.day.ago)
+            ].sort.reverse)
+
+            run_generator
+
+            assert_file CHANGELOG_FILENAME do |content|
+              assert_match('# Changelog', content)
+              assert_match('## [Unreleased]', content)
+              assert_match("## [0.1.0] - #{10.days.ago.strftime('%Y-%m-%d')}", content)
+              assert_match("## [2.0.0] - #{1.day.ago.strftime('%Y-%m-%d')}", content)
+
+              assert_match('[Unreleased]: https://github.com/HealthDataInsight/way_of_working/compare/v2.0.0...HEAD', content)
+              assert_match('[1.1.0]: https://github.com/HealthDataInsight/way_of_working/compare/v1.0.1...v1.1.0', content)
+              assert_match('[1.0.0]: https://github.com/HealthDataInsight/way_of_working/compare/v0.1.0...v1.0.0', content)
+            end
+
+            run_generator [], behavior: :revoke
+
+            assert_no_file CHANGELOG_FILENAME
+          end
+
+          test 'changelog file is created with no tags' do
+            Init.any_instance.stubs(:summary_tags).returns([])
+
+            run_generator
+
+            assert_file CHANGELOG_FILENAME do |content|
+              assert_match('# Changelog', content)
+              assert_match('## [Unreleased]', content)
+            end
+            assert_file 'docs/way_of_working/changelog.md'
+
+            run_generator [], behavior: :revoke
+
+            assert_no_file CHANGELOG_FILENAME
+            assert_no_file 'docs/way_of_working/changelog.md'
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/changelog/keepachangelog/github_audit_rule_test.rb
+++ b/test/way_of_working/changelog/keepachangelog/github_audit_rule_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# This module prevents the LoadError when requiring the base class in the GitHub audit rule
+module OverrideRequire
+  def require(path)
+    return if path == 'way_of_working/audit/github/rules/base'
+
+    super
+  end
+end
+
+module WayOfWorking
+  module Changelog
+    module Keepachangelog
+      class GithubAuditRuleTest < Minitest::Test
+        # The stub classes define WayOfWorking::Audit purely for this test. Remove it and
+        # unload the stub afterwards so each test starts without the registry already defined,
+        # regardless of the order the suite runs in.
+        def teardown
+          WayOfWorking.send(:remove_const, :Audit) if WayOfWorking.const_defined?(:Audit, false)
+          $LOADED_FEATURES.reject! { |path| path.end_with?('test/way_of_working/audit_github_stub_classes.rb') }
+        end
+
+        def test_the_rule_is_registered
+          # Check that the GitHub audit registry is unavailable by default
+          refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
+
+          require_relative '../../audit_github_stub_classes'
+
+          Kernel.prepend(OverrideRequire)
+
+          # Check that the GitHub audit registry is now available
+          assert Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
+
+          require 'way_of_working/changelog/keepachangelog/github_audit_rule'
+
+          assert ::WayOfWorking::Audit::Github::Rules::Registry.rules.values.include?(GithubAuditRule)
+          assert_equal [:way_of_working], GithubAuditRule.tags
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/decision_record/madr/generators/init_test.rb
+++ b/test/way_of_working/decision_record/madr/generators/init_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+module WayOfWorking
+  module DecisionRecord
+    module Madr
+      module Generators
+        # This class tests the DecisionRecord::Init Thor Group (generator)
+        class InitTest < Rails::Generators::TestCase
+          tests WayOfWorking::DecisionRecord::Madr::Generators::Init
+          destination WayOfWorking.root.join('tmp/generators')
+          setup :prepare_destination
+
+          test 'generator runs without errors' do
+            assert_nothing_raised do
+              run_generator
+            end
+          end
+
+          test 'files are created and revoked' do
+            run_generator
+
+            assert_file '.github/ISSUE_TEMPLATE/decision-record.md' do |content|
+              assert_match('name: Decision Record', content)
+            end
+            assert_file 'docs/decisions/README.md' do |content|
+              assert_match('This directory contains decision records for the project', content)
+            end
+            assert_file 'docs/decisions/adr-template.md' do |content|
+              assert_match('date: {YYYY-MM-DD when the decision was last updated}', content)
+              assert_match('{short title of solved problem and solution}', content)
+            end
+            assert_file 'docs/decisions/0000-use-markdown-any-decision-records.md'
+            assert_file 'docs/decisions/index.md'
+            assert_file 'docs/way_of_working/decision-records.md'
+
+            run_generator [], behavior: :revoke
+
+            assert_no_file '.github/ISSUE_TEMPLATE/decision-record.md'
+            assert_no_file 'docs/decisions/README.md'
+            assert_no_file 'docs/decisions/adr-template.md'
+            assert_no_file 'docs/decisions/0000-use-markdown-any-decision-records.md'
+            assert_no_file 'docs/decisions/index.md'
+            assert_no_file 'docs/way_of_working/decision-records.md'
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/decision_record/madr/generators/new_test.rb
+++ b/test/way_of_working/decision_record/madr/generators/new_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module WayOfWorking
+  module DecisionRecord
+    module Madr
+      module Generators
+        # This class tests the DecisionRecord::New Thor Group (generator)
+        class NewTest < Rails::Generators::TestCase
+          tests WayOfWorking::DecisionRecord::Madr::Generators::New
+          destination WayOfWorking.root.join('tmp/generators')
+          setup :prepare_destination
+
+          FIRST_TITLE = 'New_MARKUP -_Decision-record'
+          FIRST_FILENAME = 'docs/decisions/0000-new-markup-decision-record.md'
+          SECOND_TITLE = 'Second_ Decision-record'
+          SECOND_FILENAME = 'docs/decisions/0001-second-decision-record.md'
+
+          test 'generator runs without errors' do
+            assert_nothing_raised do
+              run_generator [FIRST_TITLE]
+            end
+          end
+
+          test 'file are created with incremental numbers and revoked' do
+            run_generator [FIRST_TITLE]
+
+            assert_file FIRST_FILENAME do |content|
+              assert_match("date: #{Date.today.strftime('%Y-%m-%d')}", content)
+            end
+
+            run_generator [SECOND_TITLE]
+
+            assert_file SECOND_FILENAME do |content|
+              assert_match("date: #{Date.today.strftime('%Y-%m-%d')}", content)
+            end
+
+            run_generator [FIRST_TITLE], behavior: :revoke
+            assert_no_file FIRST_FILENAME
+
+            run_generator [SECOND_TITLE], behavior: :revoke
+            assert_no_file SECOND_FILENAME
+          end
+
+          test 'filename does not contain brackets' do
+            run_generator ['Title (Has) Brackets']
+
+            assert_file 'docs/decisions/0000-title-has-brackets.md' do |content|
+              assert_match('# Title (Has) Brackets', content)
+              assert_match("date: #{Date.today.strftime('%Y-%m-%d')}", content)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/decision_record/madr/github_audit_rule_test.rb
+++ b/test/way_of_working/decision_record/madr/github_audit_rule_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# This module prevents the LoadError when requiring the base class in the GitHub audit rule
+module OverrideRequire
+  def require(path)
+    return if path == 'way_of_working/audit/github/rules/base'
+
+    super
+  end
+end
+
+module WayOfWorking
+  module DecisionRecord
+    module Madr
+      class GithubAuditRuleTest < Minitest::Test
+        def test_the_rule_is_registered
+          # Check that the GitHub audit registry is unavailable by default
+          refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
+
+          require_relative '../../audit_github_stub_classes'
+
+          Kernel.prepend(OverrideRequire)
+
+          # Check that the GitHub audit registry is now available
+          assert Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
+
+          require 'way_of_working/decision_record/madr/github_audit_rule'
+
+          assert ::WayOfWorking::Audit::Github::Rules::Registry.rules.values.include?(GithubAuditRule)
+          assert_equal [:way_of_working], GithubAuditRule.tags
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/decision_record/madr/github_audit_rule_test.rb
+++ b/test/way_of_working/decision_record/madr/github_audit_rule_test.rb
@@ -15,6 +15,14 @@ module WayOfWorking
   module DecisionRecord
     module Madr
       class GithubAuditRuleTest < Minitest::Test
+        # The stub classes define WayOfWorking::Audit purely for this test. Remove it and
+        # unload the stub afterwards so each test starts without the registry already defined,
+        # regardless of the order the suite runs in.
+        def teardown
+          WayOfWorking.send(:remove_const, :Audit) if WayOfWorking.const_defined?(:Audit, false)
+          $LOADED_FEATURES.reject! { |path| path.end_with?('test/way_of_working/audit_github_stub_classes.rb') }
+        end
+
         def test_the_rule_is_registered
           # Check that the GitHub audit registry is unavailable by default
           refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')

--- a/test/way_of_working/inclusive_language/alex/generators/exec_test.rb
+++ b/test/way_of_working/inclusive_language/alex/generators/exec_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module WayOfWorking
+  module InclusiveLanguage
+    module Alex
+      module Generators
+        # This class tests the InclusiveLanguage::Exec Thor Group (generator)
+        class ExecTest < Rails::Generators::TestCase
+          tests WayOfWorking::InclusiveLanguage::Alex::Generators::Exec
+          destination WayOfWorking.root.join('tmp/generators')
+
+          test 'generator runs without errors' do
+            generator_class.any_instance.stubs(:run_alex).returns(true)
+
+            assert_nothing_raised do
+              run_generator
+            end
+          end
+
+          test 'generator aborts if linters error' do
+            Rainbow.enabled = false
+
+            # alex errors
+            generator_class.any_instance.stubs(:run_alex).returns(false)
+
+            stderr = capture(:stderr) do
+              assert_raise ::SystemExit do
+                run_generator
+              end
+            end
+            assert_equal 'Inclusive language tests failed!', stderr.strip
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/inclusive_language/alex/generators/init_test.rb
+++ b/test/way_of_working/inclusive_language/alex/generators/init_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+module WayOfWorking
+  module InclusiveLanguage
+    module Alex
+      module Generators
+        # This class tests the InclusiveLanguage::Init generator
+        class InitTest < Rails::Generators::TestCase
+          tests WayOfWorking::InclusiveLanguage::Alex::Generators::Init
+          destination WayOfWorking.root.join('tmp/generators')
+          setup :prepare_destination
+
+          test 'generator runs without errors' do
+            assert_nothing_raised do
+              run_generator
+            end
+          end
+
+          test 'file is created and revoked' do
+            run_generator
+
+            assert_file '.github/workflows/inclusive-language.yml'
+            assert_file '.alexignore'
+            assert_file '.alexrc'
+            assert_file 'docs/way_of_working/inclusive-language.md'
+
+            run_generator [], behavior: :revoke
+
+            assert_no_file '.github/workflows/inclusive-language.yml'
+            assert_no_file '.alexignore'
+            assert_no_file '.alexrc'
+            assert_no_file 'docs/way_of_working/inclusive-language.md'
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/inclusive_language/alex/github_audit_rule_test.rb
+++ b/test/way_of_working/inclusive_language/alex/github_audit_rule_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# This module prevents the LoadError when requiring the base class in the GitHub audit rule
+module OverrideRequire
+  def require(path)
+    return if path == 'way_of_working/audit/github/rules/base'
+
+    super
+  end
+end
+
+module WayOfWorking
+  module InclusiveLanguage
+    module Alex
+      class GithubAuditRuleTest < Minitest::Test
+        def test_the_rule_is_registered
+          # Check that the GitHub audit registry is unavailable by default
+          refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
+
+          require_relative '../../audit_github_stub_classes'
+
+          Kernel.prepend(OverrideRequire)
+
+          # Check that the GitHub audit registry is now available
+          assert Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
+
+          require 'way_of_working/inclusive_language/alex/github_audit_rule'
+
+          assert ::WayOfWorking::Audit::Github::Rules::Registry.rules.values.include?(GithubAuditRule)
+          assert_equal [:way_of_working], GithubAuditRule.tags
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/inclusive_language/alex/github_audit_rule_test.rb
+++ b/test/way_of_working/inclusive_language/alex/github_audit_rule_test.rb
@@ -15,6 +15,14 @@ module WayOfWorking
   module InclusiveLanguage
     module Alex
       class GithubAuditRuleTest < Minitest::Test
+        # The stub classes define WayOfWorking::Audit purely for this test. Remove it and
+        # unload the stub afterwards so each test starts without the registry already defined,
+        # regardless of the order the suite runs in.
+        def teardown
+          WayOfWorking.send(:remove_const, :Audit) if WayOfWorking.const_defined?(:Audit, false)
+          $LOADED_FEATURES.reject! { |path| path.end_with?('test/way_of_working/audit_github_stub_classes.rb') }
+        end
+
         def test_the_rule_is_registered
           # Check that the GitHub audit registry is unavailable by default
           refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')


### PR DESCRIPTION
## Summary

Bundles three previously-separate plugin gems into this gem as **opt-in built-in features**, each enabled by requiring it:

- Inclusive Language (alex) — `require 'way_of_working/inclusive_language/alex'`
- Decision Records (MADR) — `require 'way_of_working/decision_record/madr'`
- Changelog (Keep a Changelog) — `require 'way_of_working/changelog/keepachangelog'`

Each ships its generators, GitHub audit rule, templates and docs, and exposes the same subcommands as before.

## Notes

- README: new **Built-in Features** section documenting each feature's opt-in `require` and subcommands; feature table rows updated from external plugins to `Built-in (...)`.
- CHANGELOG: Unreleased entries for the three bundled features.
- Made the `github_audit_rule` tests order-independent — they assert the audit registry is undefined by default, but loading the shared stub defined it process-wide, so whichever ran second failed. Added a `teardown` that removes the stub namespace and unloads the stub.
- `.mise.toml` now provisions Node LTS, and the inclusive-language workflow sets up Node via `jdx/mise-action`.

## Testing

- `bundle exec rake test` — green across multiple seeds (order-independent)
- `npx alex README.md` — no issues