### PR TITLE
Bundled further features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Decision Records:** bundled the MADR feature into this gem. It is opt in and replaces the separate `way_of_working-decision_record-madr` plugin gem.
 - **Inclusive Language:** bundled the alex feature into this gem. It is opt in and replaces the separate `way_of_working-inclusive_language-alex` plugin gem.
 - **Pull Request Template:** bundled the HDI feature into this gem. It is opt in and replaces the separate `way_of_working-pull_request_template-hdi` plugin gem.
+- **Versioning:** bundled the Semantic Versioning feature into this gem. It is opt in and replaces the separate `way_of_working-versioning-semver` plugin gem.
 - **Versioning:** documented the versioning policy in [ADR-0001](docs/decisions/0001-version-the-gem-interface-not-generated-content.md) and `CONTRIBUTING.md` — SemVer governs the gem's interface, not generated content; standard refreshes are minor, and drastic upgrades ship as additive variants.
 
 ## [2.0.1] - 2025-01-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Bundled the Changelog (Keep a Changelog) feature into this gem. It is opt in and replaces the separate `way_of_working-changelog-keepachangelog` plugin gem.
-- Bundled the Code of Conduct (Contributor Covenant) feature into this gem. It is opt in and replaces the separate `way_of_working-code_of_conduct-contributor_covenant` plugin gem.
-- Bundled the Decision Records (MADR) feature into this gem. It is opt in and replaces the separate `way_of_working-decision_record-madr` plugin gem.
-- Bundled the Inclusive Language (alex) feature into this gem. It is opt in and replaces the separate `way_of_working-inclusive_language-alex` plugin gem.
-- Bundled the Pull Request Template (HDI) feature into this gem. It is opt in and replaces the separate `way_of_working-pull_request_template-hdi` plugin gem.
+- **Changelog:** bundled the Keep a Changelog feature into this gem. It is opt in and replaces the separate `way_of_working-changelog-keepachangelog` plugin gem.
+- **Code of Conduct:** bundled the Contributor Covenant feature into this gem. It is opt in and replaces the separate `way_of_working-code_of_conduct-contributor_covenant` plugin gem.
+- **Decision Records:** bundled the MADR feature into this gem. It is opt in and replaces the separate `way_of_working-decision_record-madr` plugin gem.
+- **Inclusive Language:** bundled the alex feature into this gem. It is opt in and replaces the separate `way_of_working-inclusive_language-alex` plugin gem.
+- **Pull Request Template:** bundled the HDI feature into this gem. It is opt in and replaces the separate `way_of_working-pull_request_template-hdi` plugin gem.
+- **Versioning:** documented the versioning policy in [ADR-0001](docs/decisions/0001-version-the-gem-interface-not-generated-content.md) and `CONTRIBUTING.md` — SemVer governs the gem's interface, not generated content; standard refreshes are minor, and drastic upgrades ship as additive variants.
 
 ## [2.0.1] - 2025-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bundled the Changelog (Keep a Changelog) feature into this gem. It is opt in and replaces the separate `way_of_working-changelog-keepachangelog` plugin gem.
 - Bundled the Decision Records (MADR) feature into this gem. It is opt in and replaces the separate `way_of_working-decision_record-madr` plugin gem.
 - Bundled the Inclusive Language (alex) feature into this gem. It is opt in and replaces the separate `way_of_working-inclusive_language-alex` plugin gem.
+- Bundled the Pull Request Template (HDI) feature into this gem. It is opt in and replaces the separate `way_of_working-pull_request_template-hdi` plugin gem.
 
 ## [2.0.1] - 2025-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Bundled the Changelog (Keep a Changelog) feature into this gem. It is opt in and replaces the separate `way_of_working-changelog-keepachangelog` plugin gem.
+- Bundled the Code of Conduct (Contributor Covenant) feature into this gem. It is opt in and replaces the separate `way_of_working-code_of_conduct-contributor_covenant` plugin gem.
 - Bundled the Decision Records (MADR) feature into this gem. It is opt in and replaces the separate `way_of_working-decision_record-madr` plugin gem.
 - Bundled the Inclusive Language (alex) feature into this gem. It is opt in and replaces the separate `way_of_working-inclusive_language-alex` plugin gem.
 - Bundled the Pull Request Template (HDI) feature into this gem. It is opt in and replaces the separate `way_of_working-pull_request_template-hdi` plugin gem.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Audit:** bundled the GitHub audit feature into this gem. It is opt in and replaces the separate `way_of_working-audit-github` plugin gem.
 - **Changelog:** bundled the Keep a Changelog feature into this gem. It is opt in and replaces the separate `way_of_working-changelog-keepachangelog` plugin gem.
 - **Code of Conduct:** bundled the Contributor Covenant feature into this gem. It is opt in and replaces the separate `way_of_working-code_of_conduct-contributor_covenant` plugin gem.
 - **Decision Records:** bundled the MADR feature into this gem. It is opt in and replaces the separate `way_of_working-decision_record-madr` plugin gem.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+Bug reports and pull requests are welcome on GitHub at
+<https://github.com/HealthDataInsight/way_of_working>. This project is intended to be a safe,
+welcoming space for collaboration, and contributors are expected to adhere to the
+[code of conduct](CODE_OF_CONDUCT.md).
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then run `rake test` to run
+the tests. You can also run `bin/console` for an interactive prompt that lets you experiment.
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html), but SemVer here
+governs the gem's **public interface**, not the content of the artefacts its generators emit. The
+versioned contract is:
+
+* the **CLI surface** — commands and their required options;
+* the **require paths** of built-in features
+  (e.g. `require 'way_of_working/code_of_conduct/contributor_covenant'`);
+* the **plugin registration API** (`SubCommands::*.register`, the `way_of_working-*` autoload).
+
+Refreshing the standard a feature embeds (e.g. a new Contributor Covenant or MADR version) changes
+generated content but not the interface, so it is **not** a major change. See
+[ADR-0001](docs/decisions/0001-version-the-gem-interface-not-generated-content.md) for the full
+rationale.
+
+### Choosing the version bump
+
+| Change | Bump |
+| --- | --- |
+| Rename/remove a command or required option, move a feature's require path, or change the plugin API | **MAJOR** |
+| Refresh the standard a feature embeds; add a new feature or variant | **MINOR** |
+| Drastic standard upgrade shipped as a **new variant** alongside the existing one | **MINOR** (additive) |
+| Bug fix in generation or generated output | **PATCH** |
+
+For a standard update drastic enough to surprise existing users (e.g. Contributor Covenant
+2.1 → 3, effectively a rewrite), add a **new variant** under the feature's `category/variant`
+namespace rather than mutating the existing one. Both variants then coexist and consumers opt in by
+require path — keeping the change additive and leaving existing users untouched.
+
+### Changelog convention
+
+All notable changes are recorded in `CHANGELOG.md` following
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Scope feature-affecting entries with a
+bold feature prefix so each feature's history stays greppable within the single file, e.g.:
+
+```text
+- **Code of Conduct:** upgraded Contributor Covenant 2.1 → 3 via new `contributor_covenant_v3` variant
+```
+
+## Releasing
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new
+version:
+
+1. Decide the bump using the table above.
+2. Update the version number in `lib/way_of_working/version.rb`.
+3. Move the `[Unreleased]` changelog entries under the new version heading.
+4. Run `bundle exec rake release`, which creates a git tag for the version, pushes the commits and
+   tag, and pushes the `.gem` file to [rubygems.org](https://rubygems.org).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Below is a list of plugins that have been implemented so far:
 | Decision Records      | Built-in (decision_record/madr)        | Implements [MADR v3] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Inclusive Language    | Built-in (inclusive_language/alex)     | Implements [alex] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Pull Request Template | Built-in (pull_request_template/hdi)   | Implements a bespoke PR template — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
-| Versioning            | [versioning-semver]                    | Implements [Semantic Versioning v2.0.0]                                                |
+| Versioning            | Built-in (versioning/semver)           | Implements [Semantic Versioning v2.0.0] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 
 Some features are **Built-in** — they ship inside this gem and are enabled by requiring them (see [Built-in Features](#built-in-features)); the others are separate plugin gems that you add as dependencies.
 
@@ -200,6 +200,23 @@ Once required, a subcommand becomes available:
 way_of_working init pull_request_template
 ```
 
+#### Versioning
+
+A shared versioning standard makes software changes easy to communicate and releases predictable to manage across projects, so consumers can reason about compatibility at a glance.
+
+This feature documents [Semantic Versioning v2.0.0] as the project's versioning standard. Enable it by requiring it:
+
+```ruby
+require 'way_of_working/versioning/semver'
+```
+
+Once required, a subcommand becomes available:
+
+```bash
+# Add the Semantic Versioning documentation to your project
+way_of_working init versioning
+```
+
 ### Help
 
 More help on using the command line tool is found by using:
@@ -253,4 +270,3 @@ Everyone interacting in the WayOfWorking project's codebases, issue trackers, ch
 [RuboCop]: https://rubocop.org
 [Semantic Versioning v2.0.0]: https://semver.org/spec/v2.0.0.html
 [code_linting-hdi]: https://github.com/HealthDataInsight/way_of_working-code_linting-hdi
-[versioning-semver]: https://github.com/HealthDataInsight/way_of_working-versioning-semver

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Below is a list of plugins that have been implemented so far:
 | Code of Conduct       | [code_of_conduct-contributor_covenant] | Implements [Contributor Covenant v2.1]                                                 |
 | Decision Records      | Built-in (decision_record/madr)        | Implements [MADR v3] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Inclusive Language    | Built-in (inclusive_language/alex)     | Implements [alex] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
-| Pull Request Template | [pull_request_template-hdi]            | Implements a bespoke PR template                                                       |
+| Pull Request Template | Built-in (pull_request_template/hdi)   | Implements a bespoke PR template — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Versioning            | [versioning-semver]                    | Implements [Semantic Versioning v2.0.0]                                                |
 
 Some features are **Built-in** — they ship inside this gem and are enabled by requiring them (see [Built-in Features](#built-in-features)); the others are separate plugin gems that you add as dependencies.
@@ -121,6 +121,23 @@ way_of_working init inclusive_language
 way_of_working exec inclusive_language
 ```
 
+#### Pull Request Template
+
+A consistent pull request template standardises PR submissions, giving reviewers the context they need, improving review efficiency, and keeping a searchable project history.
+
+This feature installs a bespoke HDI pull request template along with its accompanying guidelines documentation. Enable it by requiring it:
+
+```ruby
+require 'way_of_working/pull_request_template/hdi'
+```
+
+Once required, a subcommand becomes available:
+
+```bash
+# Add the pull request template and documentation to your project
+way_of_working init pull_request_template
+```
+
 ### Help
 
 More help on using the command line tool is found by using:
@@ -160,5 +177,4 @@ Everyone interacting in the WayOfWorking project's codebases, issue trackers, ch
 [audit-github]: https://github.com/HealthDataInsight/way_of_working-audit-github
 [code_linting-hdi]: https://github.com/HealthDataInsight/way_of_working-code_linting-hdi
 [code_of_conduct-contributor_covenant]: https://github.com/HealthDataInsight/way_of_working-code_of_conduct-contributor_covenant
-[pull_request_template-hdi]: https://github.com/HealthDataInsight/way_of_working-pull_request_template-hdi
 [versioning-semver]: https://github.com/HealthDataInsight/way_of_working-versioning-semver

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Below is a list of plugins that have been implemented so far:
 | Audit                 | [audit-github]                         | A framework for rules to check for incorrect content and configuration of GitHub repos |
 | Changelog             | Built-in (changelog/keepachangelog)    | Implements [keepachangelog v1.1] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Code Linting          | [code_linting-hdi]                     | Implements a combination of [MegaLinter] and [RuboCop] built on NDRS standards         |
-| Code of Conduct       | [code_of_conduct-contributor_covenant] | Implements [Contributor Covenant v2.1]                                                 |
+| Code of Conduct       | Built-in (code_of_conduct/contributor_covenant) | Implements [Contributor Covenant v2.1] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Decision Records      | Built-in (decision_record/madr)        | Implements [MADR v3] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Inclusive Language    | Built-in (inclusive_language/alex)     | Implements [alex] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Pull Request Template | Built-in (pull_request_template/hdi)   | Implements a bespoke PR template — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
@@ -80,6 +80,25 @@ Once required, a subcommand becomes available:
 # Add a Keep a Changelog CHANGELOG.md and documentation to your project
 way_of_working init changelog
 ```
+
+#### Code of Conduct
+
+A code of conduct sets clear expectations for acceptable behaviour within a community or project, helping to create a safer, more welcoming and inclusive environment and giving maintainers a basis for addressing inappropriate behaviour.
+
+This feature installs the [Contributor Covenant v2.1] code of conduct along with its accompanying documentation. Enable it by requiring it:
+
+```ruby
+require 'way_of_working/code_of_conduct/contributor_covenant'
+```
+
+Once required, a subcommand becomes available:
+
+```bash
+# Add the Contributor Covenant code of conduct and documentation to your project
+way_of_working init code_of_conduct --contact-method [CONTACT METHOD]
+```
+
+You will need to provide a `[CONTACT METHOD]`, usually an email address, for community leaders to receive reports of unacceptable behavior.
 
 #### Decision Records
 
@@ -176,5 +195,4 @@ Everyone interacting in the WayOfWorking project's codebases, issue trackers, ch
 [Semantic Versioning v2.0.0]: https://semver.org/spec/v2.0.0.html
 [audit-github]: https://github.com/HealthDataInsight/way_of_working-audit-github
 [code_linting-hdi]: https://github.com/HealthDataInsight/way_of_working-code_linting-hdi
-[code_of_conduct-contributor_covenant]: https://github.com/HealthDataInsight/way_of_working-code_of_conduct-contributor_covenant
 [versioning-semver]: https://github.com/HealthDataInsight/way_of_working-versioning-semver

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Below is a list of plugins that have been implemented so far:
 
 Some features are **Built-in** — they ship inside this gem and are enabled by requiring them (see [Built-in Features](#built-in-features)); the others are separate plugin gems that you add as dependencies.
 
+The standard versions cited above (Contributor Covenant v2.1, MADR v3, and so on) describe the content a feature generates, not the gem's interface. They advance through **minor** releases — see [Versioning Policy](#versioning-policy).
+
 ## Installation
 
 Install the gem and add to the application's Gemfile by executing:
@@ -174,9 +176,25 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 When creating plugins, the convention is to create them within the WayOfWorking and feature namespaces. E.g. 
 
+### Versioning Policy
+
+This project follows [Semantic Versioning][Semantic Versioning v2.0.0], but SemVer governs the gem's **public interface** — the CLI commands and their options, the require paths of built-in features, and the plugin registration API — not the content of the artefacts its generators emit.
+
+Consequently:
+
+- Refreshing the standard a feature embeds (e.g. a new Contributor Covenant or MADR version) is **new behaviour → MINOR**.
+- A bug fix in generation is **PATCH**.
+- **MAJOR** is reserved for breaking the interface above (renaming or removing a command or option, moving a require path, or changing the plugin API).
+
+For a standard update drastic enough to surprise existing users, we add a **new variant** under the feature's `category/variant` namespace rather than mutating the existing one, so both coexist and consumers opt in by require path. This keeps the change additive (MINOR) and leaves existing users untouched.
+
+See [ADR-0001](docs/decisions/0001-version-the-gem-interface-not-generated-content.md) for the full rationale and [`CONTRIBUTING.md`](CONTRIBUTING.md) for the version-bump checklist.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at <https://github.com/HealthDataInsight/way_of_working>. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/HealthDataInsight/way_of_working/blob/main/CODE_OF_CONDUCT.md).
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for development setup, the versioning policy and the release process.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Below is a list of plugins that have been implemented so far:
 
 | Feature               | Plugin                                 | Description                                                                            |
 | --------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------|
-| Audit                 | [audit-github]                         | A framework for rules to check for incorrect content and configuration of GitHub repos |
+| Audit                 | Built-in (audit/github)                | A framework for rules to check for incorrect content and configuration of GitHub repos — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Changelog             | Built-in (changelog/keepachangelog)    | Implements [keepachangelog v1.1] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
 | Code Linting          | [code_linting-hdi]                     | Implements a combination of [MegaLinter] and [RuboCop] built on NDRS standards         |
 | Code of Conduct       | Built-in (code_of_conduct/contributor_covenant) | Implements [Contributor Covenant v2.1] — bundled, opt in by `require` (see [Built-in Features](#built-in-features)) |
@@ -65,6 +65,47 @@ You will need to provide the Code of Conduct `[CONTACT METHOD]`, usually an emai
 ### Built-in Features
 
 Some features are bundled with this gem rather than shipped as separate plugins. These built-in features are **opt in**: enable one by requiring it wherever you load Way of Working — for example in your organisation's Way of Working gem, or in your project's `Rakefile`.
+
+#### Audit
+
+Auditing your GitHub repositories against a consistent set of rules catches missing or misconfigured files and repository settings across an organisation, keeping projects aligned with your way of working. Many of the other built-in features register their own rules to check that they have been adopted properly.
+
+This feature provides a registry and auditing tool for GitHub repositories; rules can check for both missing/incorrect files and mis-configuration of the repository itself. Enable it by requiring it:
+
+```ruby
+require 'way_of_working/audit/github'
+```
+
+The audit needs two environment variables:
+
+- `GITHUB_ORGANISATION`: the name of your organisation being scanned (as used in the GitHub URL)
+- `GITHUB_TOKEN`: a PAT token with sufficient permission to access repositories and their configuration
+
+Once required, a subcommand becomes available. By default it runs only against repositories configured as git remotes in your current project:
+
+```bash
+# Audit this project's GitHub repositories
+way_of_working exec audit_github
+```
+
+Flags let you widen or narrow the scope:
+
+```bash
+# Audit every repository in the organisation
+way_of_working exec audit_github --all
+
+# Filter to repositories carrying a topic
+way_of_working exec audit_github --all --topic way-of-working
+
+# Audit one or more repositories by name (implies the whole organisation)
+way_of_working exec audit_github --name structured_store other_repo
+
+# Audit only public repositories
+way_of_working exec audit_github --all --public
+
+# Attempt to automatically fix issues where rules support it
+way_of_working exec audit_github --fix
+```
 
 #### Changelog
 
@@ -211,6 +252,5 @@ Everyone interacting in the WayOfWorking project's codebases, issue trackers, ch
 [MegaLinter]: https://megalinter.io/
 [RuboCop]: https://rubocop.org
 [Semantic Versioning v2.0.0]: https://semver.org/spec/v2.0.0.html
-[audit-github]: https://github.com/HealthDataInsight/way_of_working-audit-github
 [code_linting-hdi]: https://github.com/HealthDataInsight/way_of_working-code_linting-hdi
 [versioning-semver]: https://github.com/HealthDataInsight/way_of_working-versioning-semver

--- a/docs/decisions/0001-version-the-gem-interface-not-generated-content.md
+++ b/docs/decisions/0001-version-the-gem-interface-not-generated-content.md
@@ -1,0 +1,92 @@
+---
+# Configuration for the Jekyll template "Just the Docs"
+nav_order: 1
+parent: Decision Records
+---
+# Version the Gem Interface, Not the Generated Content
+
+## Context and Problem Statement
+
+Features that were previously extracted into separate plugin gems are being bundled back into this
+gem as opt-in built-in features (Changelog, Code of Conduct, Decision Records, Inclusive Language,
+Pull Request Template). Each feature embeds an external standard at a particular version — for
+example the Code of Conduct feature ships Contributor Covenant v2.1, and Decision Records ships
+MADR v3.
+
+This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). If every breaking
+change to a bundled standard (e.g. upgrading Contributor Covenant 2.1 → 3, which is effectively a
+rewrite) were treated as a breaking change to the gem, the major version would inflate rapidly
+towards numbers like v14. How should we version the gem as the standards its features embed evolve?
+
+## Decision Drivers
+
+* Rapid major-version inflation forces downstream consumers who pin `~> N.0` to hand-edit their
+  constraints for changes that do not actually break the gem's interface.
+* Existing users should not have their generated artefacts change underneath them without opting in.
+* The gem recommends Semantic Versioning to its own users (via the `versioning-semver` feature), so
+  it should model correct SemVer rather than abandon it.
+* Per-feature history should remain easy to follow even though all features share one version.
+
+## Considered Options
+
+* **Scope SemVer to the gem's interface** — the version reflects the CLI, require paths and plugin
+  API; the content a generator emits is not part of the versioned contract.
+* **Calendar Versioning (CalVer)** — date-based versions (e.g. `2026.06.0`); drop breaking-change
+  signalling entirely.
+* **Per-feature version numbers** — give each feature its own independently incremented version.
+
+## Decision Outcome
+
+Chosen option: **"Scope SemVer to the gem's interface"**, combined with **additive variants** for
+drastic standard upgrades, because it keeps the major version meaningful and slow-moving while
+still giving users a clear, opt-in path through breaking standard changes.
+
+The versioned public contract is:
+
+* the **CLI surface** — commands and their required options
+  (e.g. `way_of_working init code_of_conduct --contact-method`),
+* the **require paths** of built-in features
+  (e.g. `require 'way_of_working/code_of_conduct/contributor_covenant'`),
+* the **plugin registration API** (`SubCommands::*.register`, and the `way_of_working-*` autoload in
+  `lib/way_of_working.rb`).
+
+It follows that:
+
+* Refreshing the standard a feature embeds is **new behaviour → MINOR**.
+* A bug fix in generation is **PATCH**.
+* **MAJOR** is reserved for breaking the contract above — renaming or removing a command or option,
+  moving a require path, or changing the plugin API.
+
+For a standard update drastic enough to surprise existing users, prefer adding a **new variant**
+rather than mutating the existing one. Features are already namespaced as `category/variant`
+(`code_of_conduct/contributor_covenant`, `decision_record/madr`), so a v3 of Contributor Covenant
+can ship as a new variant alongside the existing one; both coexist and consumers opt in by require
+path. This keeps the change additive (MINOR) and leaves existing users untouched.
+
+### Consequences
+
+* Good, because the major version stays meaningful and rare, so `~> N.0` pins keep working across
+  routine standard refreshes.
+* Good, because breaking standard upgrades become opt-in rather than imposed on re-running a
+  generator.
+* Good, because it requires no architectural change — the variant namespace already exists.
+* Neutral, because all features still share a single version number; per-feature history is carried
+  by a changelog convention (see Validation) rather than separate version streams.
+* Bad, because contributors must consciously classify each change against the interface contract
+  rather than reflexively bumping major for anything that "looks breaking".
+
+## Validation
+
+* The version-bump checklist in `CONTRIBUTING.md` encodes this policy and is applied at release time.
+* Feature-affecting changelog entries are scoped with a bold feature prefix
+  (e.g. `- **Code of Conduct:** …`) so each feature's history is greppable within the single
+  `CHANGELOG.md`.
+
+## More Information
+
+* Rejected **CalVer** because it discards the breaking-change signal that `~>` pinning relies on and
+  would undercut the SemVer the gem advocates to its users.
+* Rejected **per-feature version numbers** because re-decoupling versions runs counter to the
+  consolidation of features back into the single gem.
+* The concrete Contributor Covenant 2.1 → 3 upgrade is tracked separately; this decision only
+  establishes how it should be versioned when it lands.

--- a/docs/decisions/0001-version-the-gem-interface-not-generated-content.md
+++ b/docs/decisions/0001-version-the-gem-interface-not-generated-content.md
@@ -25,7 +25,7 @@ towards numbers like v14. How should we version the gem as the standards its fea
 * Existing users should not have their generated artefacts change underneath them without opting in.
 * The gem recommends Semantic Versioning to its own users (via the `versioning-semver` feature), so
   it should model correct SemVer rather than abandon it.
-* Per-feature history should remain easy to follow even though all features share one version.
+* Each feature's history should remain possible to trace even though all features share one version.
 
 ## Considered Options
 

--- a/lib/way_of_working.rb
+++ b/lib/way_of_working.rb
@@ -22,6 +22,7 @@ loader.ignore(File.expand_path('way_of_working/decision_record/madr/github_audit
 loader.ignore(File.expand_path('way_of_working/inclusive_language/alex/github_audit_rule.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/pull_request_template/hdi/github_audit_rule.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/readme_badge/github_audit_rule.rb', __dir__))
+loader.ignore(File.expand_path('way_of_working/versioning/semver/github_audit_rule.rb', __dir__))
 loader.setup
 
 # This is the namespace for everything associated with the Way of Working

--- a/lib/way_of_working.rb
+++ b/lib/way_of_working.rb
@@ -17,6 +17,7 @@ loader.ignore(File.expand_path('way_of_working/tasks.rb', __dir__))
 # requires a constant from that plugin at the top of the file. Exclude it
 # from Zeitwerk's eager-load walk so its absence doesn't break the loader.
 loader.ignore(File.expand_path('way_of_working/changelog/keepachangelog/github_audit_rule.rb', __dir__))
+loader.ignore(File.expand_path('way_of_working/code_of_conduct/contributor_covenant/github_audit_rule.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/decision_record/madr/github_audit_rule.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/inclusive_language/alex/github_audit_rule.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/pull_request_template/hdi/github_audit_rule.rb', __dir__))

--- a/lib/way_of_working.rb
+++ b/lib/way_of_working.rb
@@ -19,6 +19,7 @@ loader.ignore(File.expand_path('way_of_working/tasks.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/changelog/keepachangelog/github_audit_rule.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/decision_record/madr/github_audit_rule.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/inclusive_language/alex/github_audit_rule.rb', __dir__))
+loader.ignore(File.expand_path('way_of_working/pull_request_template/hdi/github_audit_rule.rb', __dir__))
 loader.ignore(File.expand_path('way_of_working/readme_badge/github_audit_rule.rb', __dir__))
 loader.setup
 

--- a/lib/way_of_working/audit/github.rb
+++ b/lib/way_of_working/audit/github.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative 'github/generators/exec'
+
+module WayOfWorking
+  module Audit
+    module Github
+      class Error < StandardError; end
+    end
+  end
+
+  module SubCommands
+    # This reopens the "way_of_working exec" sub command
+    class Exec
+      register(Audit::Github::Generators::Exec, 'audit_github', 'audit_github',
+               <<~LONGDESC)
+                 Description:
+                     This runs the GitHub audit
+
+                 Example:
+                     way_of_working exec audit_github
+               LONGDESC
+    end
+  end
+end

--- a/lib/way_of_working/audit/github/auditor.rb
+++ b/lib/way_of_working/audit/github/auditor.rb
@@ -1,0 +1,44 @@
+require 'octokit'
+require_relative 'rules/registry'
+
+module WayOfWorking
+  module Audit
+    module Github
+      # This auditor runs all the rules against any given GitHub repository
+      class Auditor
+        def initialize(access_token, organisation_name, fix = false)
+          @access_token = access_token
+          @organisation_name = organisation_name
+          @fix = fix
+        end
+
+        def audit(repository)
+          # Get all the rules once, rather than repeatedly in individual rules
+          rulesets = @client.get("repos/#{repository.full_name}/rulesets").map do |rule|
+            @client.get("repos/#{repository.full_name}/rulesets/#{rule[:id]}")
+          end
+
+          Array(Rules::Registry.rules).each do |rule_name, klass|
+            rule = klass.new(client, rule_name, repository, rulesets, @fix)
+
+            yield rule
+          end
+        end
+
+        def repositories
+          @repositories ||= client.org_repos(@organisation_name)
+        end
+
+        private
+
+        def client
+          @client ||= begin
+            client = Octokit::Client.new(access_token: @access_token) # , per_page: 1_000
+            client.auto_paginate = true
+            client
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/audit/github/generators/exec.rb
+++ b/lib/way_of_working/audit/github/generators/exec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'git'
+require 'rainbow'
+require 'thor'
+require 'way_of_working/audit/github/auditor'
+# require 'way_of_working/github_audit/rules/all'
+
+module WayOfWorking
+  module Audit
+    module Github
+      module Generators
+        # This generator runs the github audit
+        class Exec < Thor::Group
+          class_option :all, type: :boolean, default: false,
+                             desc: 'Audit all repositories in the organisation (not just this repo)'
+
+          class_option :fix, type: :boolean, default: false,
+                             desc: 'Attempt to automatically fix issues where possible'
+
+          class_option :name, type: :array, default: nil,
+                              desc: 'Filter repositories by name (e.g., structured_store)'
+
+          class_option :public, type: :boolean, default: false,
+                                desc: 'Filter to only public repositories'
+
+          class_option :topic, type: :string, default: nil,
+                               desc: 'Filter repositories by topic (e.g., way-of-working)'
+
+          desc 'This runs the github audit on this project'
+
+          def check_for_github_token_environment_variables
+            @github_token = ENV.fetch('GITHUB_TOKEN', nil)
+            return unless @github_token.nil?
+
+            abort(Rainbow("\nMissing GITHUB_TOKEN environment variable").red)
+          end
+
+          def check_for_github_organisation_environment_variables
+            @github_organisation = ENV.fetch('GITHUB_ORGANISATION', nil)
+            return unless @github_organisation.nil?
+
+            abort(Rainbow("\nMissing GITHUB_ORGANISATION environment variable").red)
+          end
+
+          def start_timer
+            @start_time = Time.now
+          end
+
+          def check_github_organisation_remotes
+            abort(Rainbow("\nGitHub is not an upstream repository.").red) if github_organisation_remotes.empty?
+
+            # say("Limiting audit to #{path}\n", :yellow) if path
+            say "\nRunning..."
+          end
+
+          def prep_audit
+            @auditor = ::WayOfWorking::Audit::Github::Auditor.new(@github_token, @github_organisation, options[:fix])
+
+            # Loop though all the repos
+            @repositories = @auditor.repositories
+          rescue Octokit::Unauthorized
+            abort(Rainbow("\nGITHUB_TOKEN has expired or does not have sufficient permission").red)
+          end
+
+          def filter_all_if_specified
+            return if options[:all] || options[:name]
+
+            @repositories = @repositories.select do |repo|
+              github_organisation_remotes.include?(repo.name)
+            end
+          end
+
+          def filter_by_name_array_if_specified
+            return unless options[:name]
+
+            @repositories = @repositories.select do |repo|
+              options[:name].include?(repo.name)
+            end
+          end
+
+          def filter_by_topic_if_specified
+            return unless options[:topic]
+
+            @repositories = @repositories.select do |repo|
+              repo.topics.include?(options[:topic])
+            end
+          end
+
+          def filter_by_visibility_if_specified
+            return unless options[:public]
+
+            @repositories = @repositories.reject(&:private?)
+          end
+
+          def run_audit
+            @audit_ok = true
+            unarchived_repos.each do |repo|
+              @auditor.audit(repo) do |rule|
+                case rule.status
+                when :not_applicable
+                  # Do nothing
+                when :passed
+                  say "  ✅ #{rule.tags.inspect} Passed #{rule.name}"
+                when :failed
+                  say "  ❌ #{rule.tags.inspect} Failed #{rule.name}: #{rule.errors.to_sentence}"
+                  @audit_ok = false
+                else
+                  abort(Rainbow("Unknown response #{rule.status.inspect}").red)
+                end
+              end
+            end
+          end
+
+          def run_last
+            say("\nTotal time taken: #{(Time.now - @start_time).to_i} seconds", :yellow)
+
+            if @audit_ok
+              say("\nGitHub audit succeeded!", :green)
+            else
+              abort(Rainbow("\nGitHub audit failed!").red)
+            end
+          end
+
+          private
+
+          def unarchived_repos(&block)
+            return to_enum(__method__) unless block_given?
+
+            @repositories.each do |repo|
+              next if repo.archived?
+
+              say
+              say("#{repo.name} #{repo.private? ? '🔒' : ''}", :bold)
+              say("#{repo.description} [#{repo.language}]")
+              say(repo.topics.join(' '), :cyan) unless repo.topics.empty?
+
+              block.call(repo)
+            end
+          end
+
+          # This method returns the repo names for all upstream repositories
+          # hosted on GitHub, for the given organisation
+          def github_organisation_remotes
+            @github_organisation_remotes ||= begin
+              all_remote_urls = ::Git.open('.').remotes.map(&:url)
+
+              organisation_remote_urls = all_remote_urls.select do |url|
+                url.start_with?("https://github.com/#{@github_organisation}")
+              end
+
+              organisation_remote_urls.map do |url|
+                matchdata = url.match(%r{\Ahttps://github.com/([^/]+)/([^/]+)\.git})
+
+                matchdata[2]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/audit/github/rules/base.rb
+++ b/lib/way_of_working/audit/github/rules/base.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
-# This file provides simplified versions of the classes used by the GitHub audit rule registry
-# It deliberately avoids the Zeitwerk naming convention to ensure it isn't autoloaded.
+require 'active_support'
+require 'active_support/core_ext'
+require 'base64'
+require 'octokit'
+require_relative 'registry'
+
 module WayOfWorking
   module Audit
     module Github
       module Rules
-        # This is a simplified version of the base class for GitHub audit rules
+        # This is the base class for GitHub audit rules
         class Base
           attr_accessor :errors, :name, :rulesets, :warnings
+          attr_reader :fix
 
           class << self
             # Stores and return the source root for this class
@@ -31,10 +36,19 @@ module WayOfWorking
 
           def status
             @status ||= begin
-              validate
+              result = validate
 
-              @errors.empty? ? :passed : :failed
+              if result == :not_applicable
+                result
+              else
+                @errors.empty? ? :passed : :failed
+              end
             end
+          end
+
+          def validate
+            $stdout.puts "Rule#valid? has been deprecated, use \"validate\" in #{self.class.name}"
+            valid?
           end
 
           def self.tags
@@ -53,38 +67,22 @@ module WayOfWorking
           rescue Octokit::NotFound
             nil
           end
-        end
 
-        # This provides the GitHub audit rule factory
-        module Registry
-          class << self
-            attr_accessor :rules
+          # This method returns the content of the README file
+          def readme_content
+            @readme_content ||=
+              begin
+                response = @client.readme(@repo_name)
 
-            def register(klass, rule_name)
-              @rules ||= {}
-
-              @rules[rule_name] = klass
-            end
-
-            def unregister(*rule_names)
-              rule_names.each do |rule_name|
-                @rules.delete(rule_name)
+                Base64.decode64(response.content).force_encoding('UTF-8')
+              rescue Octokit::NotFound
+                ''
               end
-            end
-
-            def rule(rule_name, *args)
-              klass = Registry.rules.fetch(rule_name, Unknown)
-
-              klass.new(*args)
-            end
           end
-        end
 
-        # This is a stub handler for rules that aren't in the registry.
-        class Unknown < Base
-          def initialize(*args)
-            super
-            raise 'Error: Unknown client'
+          # This convenience method returns the branch rules for this repo
+          def branch_rules(branch)
+            @client.get("repos/#{@repo.full_name}/rules/branches/#{branch}")
           end
         end
       end

--- a/lib/way_of_working/audit/github/rules/registry.rb
+++ b/lib/way_of_working/audit/github/rules/registry.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative 'unknown'
+
+module WayOfWorking
+  module Audit
+    module Github
+      module Rules
+        # This provides the GitHub audit rule factory
+        module Registry
+          class << self
+            attr_accessor :rules
+
+            def register(klass, rule_name)
+              @rules ||= {}
+
+              @rules[rule_name] = klass
+            end
+
+            def unregister(*rule_names)
+              rule_names.each do |rule_name|
+                @rules.delete(rule_name)
+              end
+            end
+
+            def rule(rule_name, client, repo)
+              klass = Registry.rules.fetch(rule_name, Unknown)
+
+              klass.new(client, repo)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/audit/github/rules/unknown.rb
+++ b/lib/way_of_working/audit/github/rules/unknown.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module WayOfWorking
+  module Audit
+    module Github
+      module Rules
+        # This is a stub handler for rules that aren't in the registry.
+        class Unknown < Base
+          def initialize(client, name, repo, rulesets, fix = false)
+            super
+            raise 'Error: Unknown client'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/code_of_conduct/contributor_covenant.rb
+++ b/lib/way_of_working/code_of_conduct/contributor_covenant.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative 'contributor_covenant/generators/init'
+
+# If way_of_working-audit-github is used we can add a rule
+begin
+  require 'way_of_working/audit/github/rules/registry'
+  require_relative 'contributor_covenant/github_audit_rule'
+rescue LoadError # rubocop:disable Lint/SuppressedException
+end
+
+module WayOfWorking
+  module CodeOfConduct
+    module ContributorCovenant
+      class Error < StandardError; end
+    end
+  end
+
+  module SubCommands
+    # This reopens the "way_of_working init" sub command
+    class Init
+      register(CodeOfConduct::ContributorCovenant::Generators::Init, 'code_of_conduct',
+               'code_of_conduct --contact-method [CONTACT METHOD]',
+               <<~LONGDESC)
+                 Description:
+                     This adds the Contributor Covenant v2.1 code of conduct to the project
+
+                 Example:
+                     way_of_working init code_of_conduct --contact-method "foo@bar.com"
+
+                     This will create:
+                         CODE_OF_CONDUCT.md
+               LONGDESC
+    end
+  end
+end

--- a/lib/way_of_working/code_of_conduct/contributor_covenant/generators/init.rb
+++ b/lib/way_of_working/code_of_conduct/contributor_covenant/generators/init.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'way_of_working/paths'
+
+module WayOfWorking
+  module CodeOfConduct
+    module ContributorCovenant
+      module Generators
+        # This class fetches the CODE_OF_CONDUCT.md and inserts the contact method
+        class Init < Thor::Group
+          include Thor::Actions
+
+          source_root WayOfWorking.root.join('lib', 'way_of_working', 'code_of_conduct', 'contributor_covenant',
+                                             'templates')
+
+          class_option :contact_method, required: true
+
+          # Use this method to update the cached template when required
+          # def download_and_save_code_of_conduct_template
+          #   code_of_conduct_file = 'lib/way_of_working/templates/CODE_OF_CONDUCT.md.tt'
+
+          #   get 'https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md',
+          #       code_of_conduct_file
+          #   gsub_file code_of_conduct_file, '[INSERT CONTACT METHOD]',
+          #             "<<%= options['contact_method'] %>>"
+          # end
+
+          def add_code_of_conduct_to_project
+            template 'CODE_OF_CONDUCT.md'
+          end
+
+          def add_way_of_working_documentation
+            copy_file 'docs/way_of_working/code-of-conduct.md'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/code_of_conduct/contributor_covenant/github_audit_rule.rb
+++ b/lib/way_of_working/code_of_conduct/contributor_covenant/github_audit_rule.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'way_of_working/audit/github/rules/base'
+
+module WayOfWorking
+  module CodeOfConduct
+    # The namespace for this plugin
+    module ContributorCovenant
+      # This rule checks for the MegaLinter workflow action and README badge.
+      class GithubAuditRule < ::WayOfWorking::Audit::Github::Rules::Base
+        def validate
+          @errors << 'No Contributor Covenant code of conduct found' unless code_of_conduct?
+        end
+
+        private
+
+        def code_of_conduct?
+          response = @client.contents(@repo_name, path: 'CODE_OF_CONDUCT.md')
+          decoded_content = Base64.decode64(response.content)
+
+          decoded_content.include?('# Contributor Covenant Code of Conduct')
+        rescue Octokit::NotFound
+          false
+        end
+      end
+
+      ::WayOfWorking::Audit::Github::Rules::Registry.register(
+        GithubAuditRule, 'Contributor Covenant Code Of Conduct'
+      )
+    end
+  end
+end

--- a/lib/way_of_working/code_of_conduct/contributor_covenant/templates/CODE_OF_CONDUCT.md.tt
+++ b/lib/way_of_working/code_of_conduct/contributor_covenant/templates/CODE_OF_CONDUCT.md.tt
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not only for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<<%= options['contact_method'] %>>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/lib/way_of_working/code_of_conduct/contributor_covenant/templates/docs/way_of_working/code-of-conduct.md
+++ b/lib/way_of_working/code_of_conduct/contributor_covenant/templates/docs/way_of_working/code-of-conduct.md
@@ -1,0 +1,78 @@
+---
+layout: page
+status: REQUIRED
+enforcement: manual
+---
+# Code of Conduct
+
+## Purpose
+
+We adopt the [Contributor Covenant v2.1][covenant] to establish clear behavioural expectations, create safe inclusive environments, prevent discrimination/harassment, and reduce conflicts.
+
+{: .important }
+Adoption requires more than adding `CODE_OF_CONDUCT.md`. Please read the [enforcement guidelines][enforcement] and discuss with your team.
+
+## Scope
+
+Applies to all project spaces and community interactions.
+
+**Promotes:** Respectful communication, collaboration, inclusive language, professional conduct
+
+**Prevents:** Discrimination, harassment, unprofessional behaviour
+
+## Requirements
+
+1. Contact method for reports (email address)
+2. Enforcement responsibilities and process
+3. Consequences framework
+
+{: .note }
+Use HDI Code of Conduct email address as contact method.
+
+## Setup
+
+```bash
+way_of_working init code_of_conduct --contact-method [CONTACT METHOD]
+```
+
+## Usage
+
+Command creates `CODE_OF_CONDUCT.md` in repository root.
+
+**Post-setup:**
+
+1. Review enforcement guidelines with team
+2. Assign enforcement responsibilities
+3. Communicate adoption to contributors
+4. Link from README and CONTRIBUTING
+
+**Enforcement process:**
+Report → Review → Investigate → Apply consequence → Document
+
+## Enforcement
+
+**Consequences:**
+
+- **Warning:** First offense, minor issue
+- **Temporary ban:** Sustained inappropriate behavior
+- **Permanent ban:** Severe violations or repeat offenses
+
+**Requirements:**
+
+- Consistent enforcement by leadership
+- Confidential handling, 5-day response
+- Document incidents, annual review
+
+## Examples
+
+**Acceptable:** Welcoming language, respect differing views, accept criticism, focus on community benefit
+
+**Unacceptable:** Sexualized content, trolling/insults, harassment, publishing private info, unprofessional conduct
+
+## Resources
+
+- [Contributor Covenant v2.1][covenant]
+- [Enforcement Guidelines][enforcement]
+
+[covenant]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+[enforcement]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines

--- a/lib/way_of_working/pull_request_template/hdi.rb
+++ b/lib/way_of_working/pull_request_template/hdi.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'hdi/generators/init'
+
+# If way_of_working-audit-github is used we can add a rule
+begin
+  require 'way_of_working/audit/github/rules/registry'
+  require_relative 'hdi/github_audit_rule'
+rescue LoadError # rubocop:disable Lint/SuppressedException
+end
+
+module WayOfWorking
+  module PullRequestTemplate
+    module Hdi
+      class Error < StandardError; end
+    end
+  end
+
+  module SubCommands
+    # This reopens the "way_of_working init" sub command
+    class Init
+      register(PullRequestTemplate::Hdi::Generators::Init, 'pull_request_template', 'pull_request_template',
+               <<~LONGDESC)
+                 Description:
+                     Installs the Pull Request template into the project
+
+                 Example:
+                     way_of_working init pull_request_template
+
+                     This will create:
+                         .github/pull_request_template.md
+               LONGDESC
+    end
+  end
+end

--- a/lib/way_of_working/pull_request_template/hdi/generators/init.rb
+++ b/lib/way_of_working/pull_request_template/hdi/generators/init.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'thor'
+
+module WayOfWorking
+  module PullRequestTemplate
+    module Hdi
+      module Generators
+        # This generator adds the Pull Request template to a project
+        class Init < Thor::Group
+          include Thor::Actions
+
+          source_root WayOfWorking.root.join('lib', 'way_of_working', 'pull_request_template', 'hdi', 'templates')
+
+          def copy_pr_template_action
+            copy_file '.github/pull_request_template.md'
+          end
+
+          def copy_way_of_working_documentation
+            copy_file 'docs/way_of_working/pull-request-template-and-guidelines.md'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/pull_request_template/hdi/github_audit_rule.rb
+++ b/lib/way_of_working/pull_request_template/hdi/github_audit_rule.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'way_of_working/audit/github/rules/base'
+
+module WayOfWorking
+  module PullRequestTemplate
+    # The namespace for plugin
+    module Hdi
+      # This rule checks for the Pull Request template.
+      class GithubAuditRule < ::WayOfWorking::Audit::Github::Rules::Base
+        def validate
+          @errors << 'No Way of Working Pull Request template found' unless pull_request_template?
+        end
+
+        private
+
+        def pull_request_template?
+          response = @client.contents(@repo_name, path: '.github/pull_request_template.md')
+          decoded_content = Base64.decode64(response.content)
+
+          decoded_content.include?('## Screenshots (optional)')
+        rescue Octokit::NotFound
+          false
+        end
+      end
+
+      ::WayOfWorking::Audit::Github::Rules::Registry.register(
+        GithubAuditRule, 'Pull Request template'
+      )
+    end
+  end
+end

--- a/lib/way_of_working/pull_request_template/hdi/templates/.github/pull_request_template.md
+++ b/lib/way_of_working/pull_request_template/hdi/templates/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+# Pull Request Details
+
+## What?
+
+{Please write a few concise sentences outlining your changes and their overall impact, avoiding overly technical language. Reference relevant issue tracker tickets, but provide a stand-alone description that doesn’t require more than a few seconds to grasp.
+
+e.g. I've added support for authentication to implement feature X of service Y. It
+includes model, table, controller and test. For more background, see ticket #JIRA-123.}
+
+## Why?
+
+{Outlining the business or engineering goals this Pull Request accomplishes is often more important than the "what". For instance, adding an environment variable default value may appear uncomplicated to many. However, if it drastically alters the usage of libraries in your application, an active-voiced explanation is needed to capture the true impact of the change.
+
+e.g. These changes complete the user login and account creation experience. See #JIRA-123 for more information.}
+
+## How?
+
+{While the Pull Request diff illustrates the "how" of your changes, it's crucial to highlight major design decisions like choosing a recursive method over a loop. Explaining your reasoning helps reviewers understand your thought process and enables a more insightful review.
+
+e.g. This includes a migration, model and controller for user authentication. I'm using Devise to do the heavy lifting. I ran Devise migrations and those are included here.}
+
+## Testing?
+
+{Including tests along with code updates is essential as it prevents merging code without tests or failing tests, which could pose risks if overlooked. It's equally important to describe how you've tested harder-to-test code, like infrastructure code, and to communicate any untested conditions or edge cases and their associated risks to the reviewer.}
+
+## AI Contribution
+
+{Disclose any AI tools (e.g. GitHub Copilot, ChatGPT, Claude) used in this Pull Request, describing what they contributed. This helps reviewers understand the level of AI involvement and apply appropriate scrutiny.
+
+e.g. Claude 9.9 wrote the documentation and tests, or a team of GPT-9o agents wrote everything.}
+
+## Screenshots (optional)
+
+{Screenshots can significantly aid the review process, especially for UI-related changes, by offering before-and-after views. Even for backend code, a snapshot of the outcome, such as a CLI tool output, can be insightful. For infrastructure code, consider including the result of operations like a Terraform plan, preferably in a collapsible section, to avoid cluttering the comment space.
+
+Here’s how to do it in GitHub:
+```
+<details>
+  <summary>Terraform Plan</summary>
+
+  ### After running plan:
+</details>
+```
+}
+
+## Anything Else?
+
+{Consider discussing potential architectural modifications and technical debt while highlighting any challenges or optimisations you have identified.
+
+e.g. Let's consider using a 3rd party authentication provider for this, to offload MFA and other considerations as they arise and the privacy landscape evolves. AWS Cognito is a good option, so is Firebase. I'm happy to start researching this path.
+Let's also consider breaking this out into its own service. We can then re-use it or share the accounts with other apps in the future.}

--- a/lib/way_of_working/pull_request_template/hdi/templates/docs/way_of_working/pull-request-template-and-guidelines.md
+++ b/lib/way_of_working/pull_request_template/hdi/templates/docs/way_of_working/pull-request-template-and-guidelines.md
@@ -1,0 +1,50 @@
+---
+layout: page
+status: REQUIRED
+enforcement: manual
+---
+
+# Pull Request Template and Guidelines
+
+## Purpose
+
+Standardise PR submissions to ensure consistent context, improve review efficiency, and maintain searchable project history.
+
+## Scope
+
+Applies to all pull requests across team projects.
+
+## Requirements
+
+- PR template must be present in repository
+- All PRs must include:
+  - Summary of changes
+  - Rationale (why)
+  - Associated issue/ticket numbers
+- Follow [Code of Conduct](code-of-conduct.md) and GitHub's [How to write the perfect pull request][perfect-pr] guidelines
+
+{: .important }
+A Pull Request doesn't begin and end with the template. The tone of the request and any subsequent feedback is also very important. Read GitHub's PR communication guidelines in [How to write the perfect pull request][perfect-pr].
+
+## Setup
+
+Initialise PR template:
+
+```bash
+way_of_working init pull_request_template
+```
+
+## Usage
+
+Use the template when creating PRs. Provide all requested information professionally.
+
+## Enforcement
+
+Manual review during PR submission and code review process.
+
+## Resources
+
+- [How to write the perfect pull request][perfect-pr]
+- [Code of Conduct](code-of-conduct.md)
+
+[perfect-pr]: https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/

--- a/lib/way_of_working/versioning/semver.rb
+++ b/lib/way_of_working/versioning/semver.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'semver/generators/init'
+
+# If way_of_working-audit-github is used we can add a rule
+begin
+  require 'way_of_working/audit/github/rules/registry'
+  require_relative 'semver/github_audit_rule'
+rescue LoadError # rubocop:disable Lint/SuppressedException
+end
+
+module WayOfWorking
+  module Versioning
+    module Semver
+      class Error < StandardError; end
+    end
+  end
+
+  module SubCommands
+    # This reopens the "way_of_working init" sub command
+    class Init
+      register(Versioning::Semver::Generators::Init, 'versioning', 'versioning',
+               <<~LONGDESC)
+                 Description:
+                     This generator adds Semantic Versioning to your project
+
+                 Example:
+                     way_of_working init versioning
+
+                     This will create:
+                         docs/way_of_working/versioning.md
+               LONGDESC
+    end
+  end
+end

--- a/lib/way_of_working/versioning/semver/generators/init.rb
+++ b/lib/way_of_working/versioning/semver/generators/init.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module WayOfWorking
+  module Versioning
+    module Semver
+      module Generators
+        # This generator add the Semver files to the doc/decisions folder
+        class Init < Thor::Group
+          include Thor::Actions
+
+          source_root WayOfWorking.root.join('lib', 'way_of_working', 'versioning', 'semver', 'templates')
+
+          def copy_way_of_working_file
+            copy_file 'docs/way_of_working/versioning.md'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/way_of_working/versioning/semver/github_audit_rule.rb
+++ b/lib/way_of_working/versioning/semver/github_audit_rule.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'way_of_working/audit/github/rules/base'
+
+module WayOfWorking
+  module Versioning
+    # The namespace for this plugin
+    module Semver
+      # This rule checks for the versioning documentation
+      class GithubAuditRule < ::WayOfWorking::Audit::Github::Rules::Base
+        source_root WayOfWorking.root.join('lib', 'way_of_working', 'versioning', 'semver', 'templates')
+
+        def validate
+          validate_repo_file_contains_source_file(
+            'docs/way_of_working/versioning.md'
+          )
+        end
+
+        private
+
+        def repo_file_contains_source_file?(path)
+          repo_file_contains?(path, File.read(self.class.source_root.join(path)))
+        end
+
+        def repo_file_contains?(path, text)
+          remote_content = repo_file_contents(path)
+          return false if remote_content.nil?
+
+          remote_content.include?(text)
+        end
+
+        def validate_repo_file_contains_source_file(*paths)
+          paths.each do |path|
+            if repo_file_contents(path).nil?
+              @errors << "#{path} missing"
+              next
+            end
+
+            @errors << "#{path} does not match the source template" unless repo_file_contains_source_file?(path)
+          end
+        end
+      end
+
+      ::WayOfWorking::Audit::Github::Rules::Registry.register(
+        GithubAuditRule, 'Semantic Versioning'
+      )
+    end
+  end
+end

--- a/lib/way_of_working/versioning/semver/templates/docs/way_of_working/versioning.md
+++ b/lib/way_of_working/versioning/semver/templates/docs/way_of_working/versioning.md
@@ -1,0 +1,71 @@
+---
+layout: page
+status: REQUIRED
+enforcement: manual
+---
+
+# Versioning
+
+## Purpose
+
+Define the versioning standard for communicating software changes and managing releases across projects.
+
+## Scope
+
+Applies to all software projects requiring version identification.
+
+## Requirements
+
+Use [Semantic Versioning](https://semver.org) (semver) with format `MAJOR.MINOR.PATCH`:
+
+1. **MAJOR**: Increment for incompatible API changes
+2. **MINOR**: Increment for backwards-compatible functionality additions
+3. **PATCH**: Increment for backwards-compatible bug fixes
+
+Pre-release and build metadata labels available as extensions.
+
+## Setup
+
+No specific tooling required. Apply version numbers to:
+
+- Git tags
+- Package manifests (`package.json`, `Cargo.toml`, etc.)
+- Release notes
+- Documentation
+
+## Usage
+
+**When to increment:**
+
+- Breaking changes → increment MAJOR (e.g., 1.2.3 → 2.0.0)
+- New features (backwards-compatible) → increment MINOR (e.g., 1.2.3 → 1.3.0)
+- Bug fixes (backwards-compatible) → increment PATCH (e.g., 1.2.3 → 1.2.4)
+
+**Pre-release versions:** Append hyphen and identifiers (e.g., 1.0.0-alpha, 1.0.0-beta.1)
+
+**Build metadata:** Append plus sign and identifiers (e.g., 1.0.0+20240115)
+
+## Enforcement
+
+Manual enforcement through:
+
+- Code review verification
+- Release checklist validation
+- Automated CI checks (where configured)
+
+## Examples
+
+```text
+0.1.0     → Initial development
+1.0.0     → First stable release
+1.1.0     → Added new feature
+1.1.1     → Fixed bug
+2.0.0     → Breaking API change
+2.0.0-rc.1 → Release candidate
+1.2.3+build.456 → With build metadata
+```
+
+## Resources
+
+- [Semantic Versioning Specification](https://semver.org)
+- [Semver Calculator](https://semver.npmjs.com) - Determine version impact

--- a/test/way_of_working/audit/github/auditor_test.rb
+++ b/test/way_of_working/audit/github/auditor_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module WayOfWorking
+  module Audit
+    module Github
+      class AuditorTest < Minitest::Test
+        def test_initialize_without_fix_parameter
+          auditor = Auditor.new('test_token', 'test_org')
+
+          # We can't directly access @fix, but we can verify it's passed to rules
+          # by checking the audit method behavior
+          assert_instance_of Auditor, auditor
+        end
+
+        def test_initialize_with_fix_false
+          auditor = Auditor.new('test_token', 'test_org', false)
+
+          assert_instance_of Auditor, auditor
+        end
+
+        def test_initialize_with_fix_true
+          auditor = Auditor.new('test_token', 'test_org', true)
+
+          assert_instance_of Auditor, auditor
+        end
+
+        def test_audit_passes_fix_to_rules
+          # Create auditor with fix=true
+          auditor = Auditor.new('test_token', 'test_org', true)
+
+          # Mock the client
+          mock_client = mock
+          mock_client.stubs(:get).returns([])
+
+          # Stub the private client method using instance_variable_set
+          auditor.instance_variable_set(:@client, mock_client)
+
+          # Mock repository
+          mock_repo = stub(full_name: 'test_org/test_repo')
+
+          # Register a test rule
+          test_rule_class = Class.new(Rules::Base) do
+            def validate
+              :passed
+            end
+          end
+          Rules::Registry.register(test_rule_class, :test_rule)
+
+          # Capture the rule instance to verify fix parameter
+          rule_instance = nil
+          auditor.audit(mock_repo) do |rule|
+            rule_instance = rule
+          end
+
+          # Verify the rule was created with fix=true
+          assert_equal true, rule_instance.fix
+        ensure
+          # Clean up
+          Rules::Registry.unregister(:test_rule)
+        end
+
+        def test_audit_passes_fix_false_to_rules
+          # Create auditor with fix=false (default)
+          auditor = Auditor.new('test_token', 'test_org', false)
+
+          # Mock the client
+          mock_client = mock
+          mock_client.stubs(:get).returns([])
+
+          # Stub the private client method using instance_variable_set
+          auditor.instance_variable_set(:@client, mock_client)
+
+          # Mock repository
+          mock_repo = stub(full_name: 'test_org/test_repo')
+
+          # Register a test rule
+          test_rule_class = Class.new(Rules::Base) do
+            def validate
+              :passed
+            end
+          end
+          Rules::Registry.register(test_rule_class, :test_rule)
+
+          # Capture the rule instance to verify fix parameter
+          rule_instance = nil
+          auditor.audit(mock_repo) do |rule|
+            rule_instance = rule
+          end
+
+          # Verify the rule was created with fix=false
+          assert_equal false, rule_instance.fix
+        ensure
+          # Clean up
+          Rules::Registry.unregister(:test_rule)
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/audit/github/generators/exec_test.rb
+++ b/test/way_of_working/audit/github/generators/exec_test.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module WayOfWorking
+  module Audit
+    module Github
+      module Generators
+        class ExecTest < Rails::Generators::TestCase
+          tests WayOfWorking::Audit::Github::Generators::Exec
+          destination File.expand_path('../../../../../tmp', __dir__)
+
+          setup do
+            # Set required environment variables
+            ENV['GITHUB_TOKEN'] = 'test_token'
+            ENV['GITHUB_ORGANISATION'] = 'test_org'
+
+            # Mock Git operations
+            mock_git = mock
+            mock_git.stubs(:remotes).returns([
+                                               stub(url: 'https://github.com/test_org/test_repo.git')
+                                             ])
+            Git.stubs(:open).returns(mock_git)
+          end
+
+          teardown do
+            # Clean up environment variables
+            ENV.delete('GITHUB_TOKEN')
+            ENV.delete('GITHUB_ORGANISATION')
+          end
+
+          test 'generator has all option' do
+            assert generator_class.class_options.key?(:all)
+            assert_equal :boolean, generator_class.class_options[:all].type
+            assert_equal false, generator_class.class_options[:all].default
+          end
+
+          test 'generator has topic option' do
+            assert generator_class.class_options.key?(:topic)
+            assert_equal :string, generator_class.class_options[:topic].type
+            assert_nil generator_class.class_options[:topic].default
+          end
+
+          test 'generator has public option' do
+            assert generator_class.class_options.key?(:public)
+            assert_equal :boolean, generator_class.class_options[:public].type
+            assert_equal false, generator_class.class_options[:public].default
+          end
+
+          test 'generator has fix option' do
+            assert generator_class.class_options.key?(:fix)
+            assert_equal :boolean, generator_class.class_options[:fix].type
+            assert_equal false, generator_class.class_options[:fix].default
+          end
+
+          test 'generator has name option' do
+            assert generator_class.class_options.key?(:name)
+            assert_equal :array, generator_class.class_options[:name].type
+            assert_nil generator_class.class_options[:name].default
+          end
+
+          test 'prep_audit passes fix option to auditor when false' do
+            # Mock the auditor
+            mock_auditor = mock
+            mock_auditor.stubs(:repositories).returns([])
+
+            # Expect Auditor to be initialized with fix=false
+            Auditor.expects(:new).with('test_token', 'test_org', false).returns(mock_auditor)
+
+            # Run generator with fix=false (default)
+            generator = generator_class.new([], {}, {})
+            generator.instance_variable_set(:@github_token, 'test_token')
+            generator.instance_variable_set(:@github_organisation, 'test_org')
+            generator.prep_audit
+          end
+
+          test 'prep_audit passes fix option to auditor when true' do
+            # Mock the auditor
+            mock_auditor = mock
+            mock_auditor.stubs(:repositories).returns([])
+
+            # Expect Auditor to be initialized with fix=true
+            Auditor.expects(:new).with('test_token', 'test_org', true).returns(mock_auditor)
+
+            # Run generator with fix=true
+            generator = generator_class.new([], { fix: true }, {})
+            generator.instance_variable_set(:@github_token, 'test_token')
+            generator.instance_variable_set(:@github_organisation, 'test_org')
+            generator.prep_audit
+          end
+
+          test 'filter_all_if_specified filters repositories when all is false' do
+            # Mock the auditor
+            mock_repo1 = stub(name: 'test_repo', archived?: false)
+            mock_repo2 = stub(name: 'other_repo', archived?: false)
+            mock_auditor = mock
+            mock_auditor.stubs(:repositories).returns([mock_repo1, mock_repo2])
+
+            Auditor.stubs(:new).returns(mock_auditor)
+
+            # Run generator with all=false (default)
+            generator = generator_class.new([], {}, {})
+            generator.instance_variable_set(:@github_token, 'test_token')
+            generator.instance_variable_set(:@github_organisation, 'test_org')
+            # Stub the github_organisation_remotes method to return test_repo
+            generator.stubs(:github_organisation_remotes).returns(['test_repo'])
+            generator.prep_audit
+            generator.filter_all_if_specified
+
+            repositories = generator.instance_variable_get(:@repositories)
+            # Should only include test_repo (from git remotes)
+            assert_equal 1, repositories.length
+            assert_equal 'test_repo', repositories.first.name
+          end
+
+          test 'filter_all_if_specified does not filter repositories when all is true' do
+            # Mock the auditor
+            mock_repo1 = stub(name: 'test_repo', archived?: false)
+            mock_repo2 = stub(name: 'other_repo', archived?: false)
+            mock_auditor = mock
+            mock_auditor.stubs(:repositories).returns([mock_repo1, mock_repo2])
+
+            Auditor.stubs(:new).returns(mock_auditor)
+
+            # Run generator with all=true
+            generator = generator_class.new([], { all: true }, {})
+            generator.instance_variable_set(:@github_token, 'test_token')
+            generator.instance_variable_set(:@github_organisation, 'test_org')
+            generator.prep_audit
+            generator.filter_all_if_specified
+
+            repositories = generator.instance_variable_get(:@repositories)
+            # Should include all repos
+            assert_equal 2, repositories.length
+          end
+
+          test 'filter_by_topic_if_specified filters repositories by topic when topic is specified' do
+            # Mock the auditor
+            mock_repo1 = stub(name: 'test_repo', archived?: false, topics: %w[way-of-working ruby])
+            mock_repo2 = stub(name: 'other_repo', archived?: false, topics: ['python'])
+            mock_repo3 = stub(name: 'third_repo', archived?: false, topics: ['way-of-working'])
+            mock_auditor = mock
+            mock_auditor.stubs(:repositories).returns([mock_repo1, mock_repo2, mock_repo3])
+
+            Auditor.stubs(:new).returns(mock_auditor)
+
+            # Run generator with topic filter
+            generator = generator_class.new([], { all: true, topic: 'way-of-working' }, {})
+            generator.instance_variable_set(:@github_token, 'test_token')
+            generator.instance_variable_set(:@github_organisation, 'test_org')
+            generator.prep_audit
+            generator.filter_by_topic_if_specified
+
+            repositories = generator.instance_variable_get(:@repositories)
+            # Should only include repos with 'way-of-working' topic
+            assert_equal 2, repositories.length
+            assert_includes repositories.map(&:name), 'test_repo'
+            assert_includes repositories.map(&:name), 'third_repo'
+          end
+
+          test 'filter_by_visibility_if_specified filters repositories to only public when public is true' do
+            # Mock the auditor
+            mock_repo1 = stub(name: 'public_repo', archived?: false, private?: false)
+            mock_repo2 = stub(name: 'private_repo', archived?: false, private?: true)
+            mock_repo3 = stub(name: 'another_public_repo', archived?: false, private?: false)
+            mock_auditor = mock
+            mock_auditor.stubs(:repositories).returns([mock_repo1, mock_repo2, mock_repo3])
+
+            Auditor.stubs(:new).returns(mock_auditor)
+
+            # Run generator with public filter
+            generator = generator_class.new([], { all: true, public: true }, {})
+            generator.instance_variable_set(:@github_token, 'test_token')
+            generator.instance_variable_set(:@github_organisation, 'test_org')
+            generator.prep_audit
+            generator.filter_by_visibility_if_specified
+
+            repositories = generator.instance_variable_get(:@repositories)
+            # Should only include public repos
+            assert_equal 2, repositories.length
+            assert_includes repositories.map(&:name), 'public_repo'
+            assert_includes repositories.map(&:name), 'another_public_repo'
+          end
+
+          test 'filter_by_name_array_if_specified filters repositories by name when name is specified' do
+            # Mock the auditor
+            mock_repo1 = stub(name: 'structured_store', archived?: false)
+            mock_repo2 = stub(name: 'other_repo', archived?: false)
+            mock_repo3 = stub(name: 'another_repo', archived?: false)
+            mock_auditor = mock
+            mock_auditor.stubs(:repositories).returns([mock_repo1, mock_repo2, mock_repo3])
+
+            Auditor.stubs(:new).returns(mock_auditor)
+
+            # Run generator with name filter
+            generator = generator_class.new([], { all: true, name: ['structured_store'] }, {})
+            generator.instance_variable_set(:@github_token, 'test_token')
+            generator.instance_variable_set(:@github_organisation, 'test_org')
+            generator.prep_audit
+            generator.filter_by_name_array_if_specified
+
+            repositories = generator.instance_variable_get(:@repositories)
+            # Should only include structured_store
+            assert_equal 1, repositories.length
+            assert_equal 'structured_store', repositories.first.name
+          end
+
+          test 'filter_all_if_specified does not filter when name is specified without all' do
+            # Mock the auditor
+            mock_repo1 = stub(name: 'structured_store', archived?: false)
+            mock_repo2 = stub(name: 'other_repo', archived?: false)
+            mock_repo3 = stub(name: 'test_repo', archived?: false)
+            mock_auditor = mock
+            mock_auditor.stubs(:repositories).returns([mock_repo1, mock_repo2, mock_repo3])
+
+            Auditor.stubs(:new).returns(mock_auditor)
+
+            # Run generator with name filter only (no --all flag)
+            generator = generator_class.new([], { name: ['structured_store'] }, {})
+            generator.instance_variable_set(:@github_token, 'test_token')
+            generator.instance_variable_set(:@github_organisation, 'test_org')
+            # Stub the github_organisation_remotes method
+            generator.stubs(:github_organisation_remotes).returns(['test_repo'])
+            generator.prep_audit
+            generator.filter_all_if_specified
+
+            repositories = generator.instance_variable_get(:@repositories)
+            # Should include all repos because --name implies --all
+            assert_equal 3, repositories.length
+          end
+
+          test 'filter_by_name_array_if_specified filters repositories by multiple names when multiple names are specified' do
+            # Mock the auditor
+            mock_repo1 = stub(name: 'structured_store', archived?: false)
+            mock_repo2 = stub(name: 'other_repo', archived?: false)
+            mock_repo3 = stub(name: 'another_repo', archived?: false)
+            mock_auditor = mock
+            mock_auditor.stubs(:repositories).returns([mock_repo1, mock_repo2, mock_repo3])
+
+            Auditor.stubs(:new).returns(mock_auditor)
+
+            # Run generator with multiple name filters
+            generator = generator_class.new([], { all: true, name: %w[structured_store another_repo] }, {})
+            generator.instance_variable_set(:@github_token, 'test_token')
+            generator.instance_variable_set(:@github_organisation, 'test_org')
+            generator.prep_audit
+            generator.filter_by_name_array_if_specified
+
+            repositories = generator.instance_variable_get(:@repositories)
+            # Should only include structured_store and another_repo
+            assert_equal 2, repositories.length
+            assert_includes repositories.map(&:name), 'structured_store'
+            assert_includes repositories.map(&:name), 'another_repo'
+          end
+
+          test 'combines topic and public filters when both are specified' do
+            # Mock the auditor
+            mock_repo1 = stub(name: 'public_with_topic', archived?: false, private?: false, topics: ['way-of-working'])
+            mock_repo2 = stub(name: 'private_with_topic', archived?: false, private?: true, topics: ['way-of-working'])
+            mock_repo3 = stub(name: 'public_without_topic', archived?: false, private?: false, topics: ['other'])
+            mock_repo4 = stub(name: 'private_without_topic', archived?: false, private?: true, topics: ['other'])
+            mock_auditor = mock
+            mock_auditor.stubs(:repositories).returns([mock_repo1, mock_repo2, mock_repo3, mock_repo4])
+
+            Auditor.stubs(:new).returns(mock_auditor)
+
+            # Run generator with both topic and public filters
+            generator = generator_class.new([], { all: true, topic: 'way-of-working', public: true }, {})
+            generator.instance_variable_set(:@github_token, 'test_token')
+            generator.instance_variable_set(:@github_organisation, 'test_org')
+            generator.prep_audit
+            generator.filter_by_topic_if_specified
+            generator.filter_by_visibility_if_specified
+
+            repositories = generator.instance_variable_get(:@repositories)
+            # Should only include public repos with 'way-of-working' topic
+            assert_equal 1, repositories.length
+            assert_equal 'public_with_topic', repositories.first.name
+          end
+
+          test 'combines name, topic and public filters when all are specified' do
+            # Mock the auditor
+            mock_repo1 = stub(name: 'structured_store', archived?: false, private?: false,
+                              topics: ['way-of-working'])
+            mock_repo2 = stub(name: 'other_store', archived?: false, private?: true, topics: ['way-of-working'])
+            mock_repo3 = stub(name: 'structured_store', archived?: false, private?: false, topics: ['other'])
+            mock_repo4 = stub(name: 'public_with_topic', archived?: false, private?: false,
+                              topics: ['way-of-working'])
+            mock_auditor = mock
+            mock_auditor.stubs(:repositories).returns([mock_repo1, mock_repo2, mock_repo3, mock_repo4])
+
+            Auditor.stubs(:new).returns(mock_auditor)
+
+            # Run generator with name, topic and public filters
+            generator = generator_class.new([], { all: true, name: ['structured_store'], topic: 'way-of-working',
+                                                  public: true }, {})
+            generator.instance_variable_set(:@github_token, 'test_token')
+            generator.instance_variable_set(:@github_organisation, 'test_org')
+            generator.prep_audit
+            generator.filter_by_name_array_if_specified
+            generator.filter_by_topic_if_specified
+            generator.filter_by_visibility_if_specified
+
+            repositories = generator.instance_variable_get(:@repositories)
+            # Should only include public structured_store with 'way-of-working' topic
+            assert_equal 1, repositories.length
+            assert_equal 'structured_store', repositories.first.name
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/audit/github/rule_test.rb
+++ b/test/way_of_working/audit/github/rule_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module WayOfWorking
+  module Audit
+    module Github
+      class TestRule < Rules::Base
+      end
+
+      class RuleTest < Minitest::Test
+        def test_tags
+          # Test class method
+          assert_equal [:way_of_working], TestRule.tags
+
+          # Test instance method
+          client = mock
+          name = mock
+          repo = stub(full_name: 'test')
+          rulesets = mock
+          test_rule = TestRule.new(client, name, repo, rulesets)
+          assert_equal [:way_of_working], test_rule.tags
+        end
+
+        def test_initialize_without_fix_parameter
+          client = mock
+          name = mock
+          repo = stub(full_name: 'test/repo')
+          rulesets = mock
+
+          test_rule = TestRule.new(client, name, repo, rulesets)
+
+          assert_equal false, test_rule.fix
+        end
+
+        def test_initialize_with_fix_false
+          client = mock
+          name = mock
+          repo = stub(full_name: 'test/repo')
+          rulesets = mock
+
+          test_rule = TestRule.new(client, name, repo, rulesets, false)
+
+          assert_equal false, test_rule.fix
+        end
+
+        def test_initialize_with_fix_true
+          client = mock
+          name = mock
+          repo = stub(full_name: 'test/repo')
+          rulesets = mock
+
+          test_rule = TestRule.new(client, name, repo, rulesets, true)
+
+          assert_equal true, test_rule.fix
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/changelog/keepachangelog/github_audit_rule_test.rb
+++ b/test/way_of_working/changelog/keepachangelog/github_audit_rule_test.rb
@@ -1,41 +1,20 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-
-# This module prevents the LoadError when requiring the base class in the GitHub audit rule
-module OverrideRequire
-  def require(path)
-    return if path == 'way_of_working/audit/github/rules/base'
-
-    super
-  end
-end
+require 'way_of_working/changelog/keepachangelog/github_audit_rule'
 
 module WayOfWorking
   module Changelog
     module Keepachangelog
       class GithubAuditRuleTest < Minitest::Test
-        # The stub classes define WayOfWorking::Audit purely for this test. Remove it and
-        # unload the stub afterwards so each test starts without the registry already defined,
-        # regardless of the order the suite runs in.
+        # The rule registers itself with the (now built-in) GitHub audit registry
+        # at load time. Unregister it afterwards so the shared registry doesn't
+        # leak between tests, regardless of the order the suite runs in.
         def teardown
-          WayOfWorking.send(:remove_const, :Audit) if WayOfWorking.const_defined?(:Audit, false)
-          $LOADED_FEATURES.reject! { |path| path.end_with?('test/way_of_working/audit_github_stub_classes.rb') }
+          ::WayOfWorking::Audit::Github::Rules::Registry.rules&.delete_if { |_, klass| klass == GithubAuditRule }
         end
 
         def test_the_rule_is_registered
-          # Check that the GitHub audit registry is unavailable by default
-          refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
-
-          require_relative '../../audit_github_stub_classes'
-
-          Kernel.prepend(OverrideRequire)
-
-          # Check that the GitHub audit registry is now available
-          assert Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
-
-          require 'way_of_working/changelog/keepachangelog/github_audit_rule'
-
           assert ::WayOfWorking::Audit::Github::Rules::Registry.rules.values.include?(GithubAuditRule)
           assert_equal [:way_of_working], GithubAuditRule.tags
         end

--- a/test/way_of_working/code_of_conduct/contributor_covenant/generators/init_test.rb
+++ b/test/way_of_working/code_of_conduct/contributor_covenant/generators/init_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+module WayOfWorking
+  module CodeOfConduct
+    module ContributorCovenant
+      module Generators
+        # This class tests the CodeOfConduct::Init Thor Group (generator)
+        class InitTest < Rails::Generators::TestCase
+          tests WayOfWorking::CodeOfConduct::ContributorCovenant::Generators::Init
+          destination WayOfWorking.root.join('tmp/generators')
+          setup :prepare_destination
+
+          test 'generator requires contact-method option' do
+            stderr = capture(:stderr) do
+              run_generator
+            end
+            assert_match("No value provided for required options '--contact-method'", stderr)
+
+            stderr = capture(:stderr) do
+              run_generator %w[--contact-method foo@bar.com]
+            end
+            refute_match("No value provided for required options '--contact-method'", stderr)
+          end
+
+          test 'COC file is created and revoked' do
+            code_of_conduct_file = 'CODE_OF_CONDUCT.md'
+            run_generator %w[--contact-method foo@bar.com]
+
+            assert_file code_of_conduct_file do |content|
+              assert_match('## Our Pledge', content)
+              refute_match('[INSERT CONTACT METHOD]', content)
+            end
+            assert_file 'docs/way_of_working/code-of-conduct.md'
+
+            run_generator %w[--contact-method foo@bar.com], behavior: :revoke
+
+            assert_no_file code_of_conduct_file
+            assert_no_file 'docs/way_of_working/code-of-conduct.md'
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/code_of_conduct/contributor_covenant/github_audit_rule_test.rb
+++ b/test/way_of_working/code_of_conduct/contributor_covenant/github_audit_rule_test.rb
@@ -1,41 +1,20 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-
-# This module prevents the LoadError when requiring the base class in the GitHub audit rule
-module OverrideRequire
-  def require(path)
-    return if path == 'way_of_working/audit/github/rules/base'
-
-    super
-  end
-end
+require 'way_of_working/code_of_conduct/contributor_covenant/github_audit_rule'
 
 module WayOfWorking
   module CodeOfConduct
     module ContributorCovenant
       class GithubAuditRuleTest < Minitest::Test
-        # The stub classes define WayOfWorking::Audit purely for this test. Remove it and
-        # unload the stub afterwards so each test starts without the registry already defined,
-        # regardless of the order the suite runs in.
+        # The rule registers itself with the (now built-in) GitHub audit registry
+        # at load time. Unregister it afterwards so the shared registry doesn't
+        # leak between tests, regardless of the order the suite runs in.
         def teardown
-          WayOfWorking.send(:remove_const, :Audit) if WayOfWorking.const_defined?(:Audit, false)
-          $LOADED_FEATURES.reject! { |path| path.end_with?('test/way_of_working/audit_github_stub_classes.rb') }
+          ::WayOfWorking::Audit::Github::Rules::Registry.rules&.delete_if { |_, klass| klass == GithubAuditRule }
         end
 
         def test_the_rule_is_registered
-          # Check that the GitHub audit registry is unavailable by default
-          refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
-
-          require_relative '../../audit_github_stub_classes'
-
-          Kernel.prepend(OverrideRequire)
-
-          # Check that the GitHub audit registry is now available
-          assert Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
-
-          require 'way_of_working/code_of_conduct/contributor_covenant/github_audit_rule'
-
           assert ::WayOfWorking::Audit::Github::Rules::Registry.rules.values.include?(GithubAuditRule)
           assert_equal [:way_of_working], GithubAuditRule.tags
         end

--- a/test/way_of_working/code_of_conduct/contributor_covenant/github_audit_rule_test.rb
+++ b/test/way_of_working/code_of_conduct/contributor_covenant/github_audit_rule_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# This module prevents the LoadError when requiring the base class in the GitHub audit rule
+module OverrideRequire
+  def require(path)
+    return if path == 'way_of_working/audit/github/rules/base'
+
+    super
+  end
+end
+
+module WayOfWorking
+  module CodeOfConduct
+    module ContributorCovenant
+      class GithubAuditRuleTest < Minitest::Test
+        # The stub classes define WayOfWorking::Audit purely for this test. Remove it and
+        # unload the stub afterwards so each test starts without the registry already defined,
+        # regardless of the order the suite runs in.
+        def teardown
+          WayOfWorking.send(:remove_const, :Audit) if WayOfWorking.const_defined?(:Audit, false)
+          $LOADED_FEATURES.reject! { |path| path.end_with?('test/way_of_working/audit_github_stub_classes.rb') }
+        end
+
+        def test_the_rule_is_registered
+          # Check that the GitHub audit registry is unavailable by default
+          refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
+
+          require_relative '../../audit_github_stub_classes'
+
+          Kernel.prepend(OverrideRequire)
+
+          # Check that the GitHub audit registry is now available
+          assert Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
+
+          require 'way_of_working/code_of_conduct/contributor_covenant/github_audit_rule'
+
+          assert ::WayOfWorking::Audit::Github::Rules::Registry.rules.values.include?(GithubAuditRule)
+          assert_equal [:way_of_working], GithubAuditRule.tags
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/decision_record/madr/github_audit_rule_test.rb
+++ b/test/way_of_working/decision_record/madr/github_audit_rule_test.rb
@@ -1,41 +1,20 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-
-# This module prevents the LoadError when requiring the base class in the GitHub audit rule
-module OverrideRequire
-  def require(path)
-    return if path == 'way_of_working/audit/github/rules/base'
-
-    super
-  end
-end
+require 'way_of_working/decision_record/madr/github_audit_rule'
 
 module WayOfWorking
   module DecisionRecord
     module Madr
       class GithubAuditRuleTest < Minitest::Test
-        # The stub classes define WayOfWorking::Audit purely for this test. Remove it and
-        # unload the stub afterwards so each test starts without the registry already defined,
-        # regardless of the order the suite runs in.
+        # The rule registers itself with the (now built-in) GitHub audit registry
+        # at load time. Unregister it afterwards so the shared registry doesn't
+        # leak between tests, regardless of the order the suite runs in.
         def teardown
-          WayOfWorking.send(:remove_const, :Audit) if WayOfWorking.const_defined?(:Audit, false)
-          $LOADED_FEATURES.reject! { |path| path.end_with?('test/way_of_working/audit_github_stub_classes.rb') }
+          ::WayOfWorking::Audit::Github::Rules::Registry.rules&.delete_if { |_, klass| klass == GithubAuditRule }
         end
 
         def test_the_rule_is_registered
-          # Check that the GitHub audit registry is unavailable by default
-          refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
-
-          require_relative '../../audit_github_stub_classes'
-
-          Kernel.prepend(OverrideRequire)
-
-          # Check that the GitHub audit registry is now available
-          assert Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
-
-          require 'way_of_working/decision_record/madr/github_audit_rule'
-
           assert ::WayOfWorking::Audit::Github::Rules::Registry.rules.values.include?(GithubAuditRule)
           assert_equal [:way_of_working], GithubAuditRule.tags
         end

--- a/test/way_of_working/inclusive_language/alex/github_audit_rule_test.rb
+++ b/test/way_of_working/inclusive_language/alex/github_audit_rule_test.rb
@@ -1,41 +1,20 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-
-# This module prevents the LoadError when requiring the base class in the GitHub audit rule
-module OverrideRequire
-  def require(path)
-    return if path == 'way_of_working/audit/github/rules/base'
-
-    super
-  end
-end
+require 'way_of_working/inclusive_language/alex/github_audit_rule'
 
 module WayOfWorking
   module InclusiveLanguage
     module Alex
       class GithubAuditRuleTest < Minitest::Test
-        # The stub classes define WayOfWorking::Audit purely for this test. Remove it and
-        # unload the stub afterwards so each test starts without the registry already defined,
-        # regardless of the order the suite runs in.
+        # The rule registers itself with the (now built-in) GitHub audit registry
+        # at load time. Unregister it afterwards so the shared registry doesn't
+        # leak between tests, regardless of the order the suite runs in.
         def teardown
-          WayOfWorking.send(:remove_const, :Audit) if WayOfWorking.const_defined?(:Audit, false)
-          $LOADED_FEATURES.reject! { |path| path.end_with?('test/way_of_working/audit_github_stub_classes.rb') }
+          ::WayOfWorking::Audit::Github::Rules::Registry.rules&.delete_if { |_, klass| klass == GithubAuditRule }
         end
 
         def test_the_rule_is_registered
-          # Check that the GitHub audit registry is unavailable by default
-          refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
-
-          require_relative '../../audit_github_stub_classes'
-
-          Kernel.prepend(OverrideRequire)
-
-          # Check that the GitHub audit registry is now available
-          assert Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
-
-          require 'way_of_working/inclusive_language/alex/github_audit_rule'
-
           assert ::WayOfWorking::Audit::Github::Rules::Registry.rules.values.include?(GithubAuditRule)
           assert_equal [:way_of_working], GithubAuditRule.tags
         end

--- a/test/way_of_working/pull_request_template/hdi/generators/init_test.rb
+++ b/test/way_of_working/pull_request_template/hdi/generators/init_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+module WayOfWorking
+  module PullRequestTemplate
+    module Hdi
+      module Generators
+        # This class tests the PrTemplate::Init Thor Group (generator)
+        class InitTest < Rails::Generators::TestCase
+          tests WayOfWorking::PullRequestTemplate::Hdi::Generators::Init
+          destination WayOfWorking.root.join('tmp/generators')
+          setup :prepare_destination
+
+          test 'generator runs without errors' do
+            assert_nothing_raised do
+              run_generator
+            end
+          end
+
+          test 'files are created and revoked' do
+            run_generator
+
+            assert_file '.github/pull_request_template.md'
+            assert_file 'docs/way_of_working/pull-request-template-and-guidelines.md'
+
+            run_generator [], behavior: :revoke
+
+            assert_no_file '.github/pull_request_template.md'
+            assert_no_file 'docs/way_of_working/pull-request-template-and-guidelines.md'
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/pull_request_template/hdi/github_audit_rule_test.rb
+++ b/test/way_of_working/pull_request_template/hdi/github_audit_rule_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# This module prevents the LoadError when requiring the base class in the GitHub audit rule
+module OverrideRequire
+  def require(path)
+    return if path == 'way_of_working/audit/github/rules/base'
+
+    super
+  end
+end
+
+module WayOfWorking
+  module PullRequestTemplate
+    module Hdi
+      class GithubAuditRuleTest < Minitest::Test
+        def test_the_rule_is_registered
+          # Check that the GitHub audit registry is unavailable by default
+          refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
+
+          require_relative '../../audit_github_stub_classes'
+
+          Kernel.prepend(OverrideRequire)
+
+          # Check that the GitHub audit registry is now available
+          assert Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
+
+          require 'way_of_working/pull_request_template/hdi/github_audit_rule'
+
+          assert ::WayOfWorking::Audit::Github::Rules::Registry.rules.values.include?(GithubAuditRule)
+          assert_equal [:way_of_working], GithubAuditRule.tags
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/pull_request_template/hdi/github_audit_rule_test.rb
+++ b/test/way_of_working/pull_request_template/hdi/github_audit_rule_test.rb
@@ -1,41 +1,20 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-
-# This module prevents the LoadError when requiring the base class in the GitHub audit rule
-module OverrideRequire
-  def require(path)
-    return if path == 'way_of_working/audit/github/rules/base'
-
-    super
-  end
-end
+require 'way_of_working/pull_request_template/hdi/github_audit_rule'
 
 module WayOfWorking
   module PullRequestTemplate
     module Hdi
       class GithubAuditRuleTest < Minitest::Test
-        # The stub classes define WayOfWorking::Audit purely for this test. Remove it and
-        # unload the stub afterwards so each test starts without the registry already defined,
-        # regardless of the order the suite runs in.
+        # The rule registers itself with the (now built-in) GitHub audit registry
+        # at load time. Unregister it afterwards so the shared registry doesn't
+        # leak between tests, regardless of the order the suite runs in.
         def teardown
-          WayOfWorking.send(:remove_const, :Audit) if WayOfWorking.const_defined?(:Audit, false)
-          $LOADED_FEATURES.reject! { |path| path.end_with?('test/way_of_working/audit_github_stub_classes.rb') }
+          ::WayOfWorking::Audit::Github::Rules::Registry.rules&.delete_if { |_, klass| klass == GithubAuditRule }
         end
 
         def test_the_rule_is_registered
-          # Check that the GitHub audit registry is unavailable by default
-          refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
-
-          require_relative '../../audit_github_stub_classes'
-
-          Kernel.prepend(OverrideRequire)
-
-          # Check that the GitHub audit registry is now available
-          assert Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')
-
-          require 'way_of_working/pull_request_template/hdi/github_audit_rule'
-
           assert ::WayOfWorking::Audit::Github::Rules::Registry.rules.values.include?(GithubAuditRule)
           assert_equal [:way_of_working], GithubAuditRule.tags
         end

--- a/test/way_of_working/pull_request_template/hdi/github_audit_rule_test.rb
+++ b/test/way_of_working/pull_request_template/hdi/github_audit_rule_test.rb
@@ -15,6 +15,14 @@ module WayOfWorking
   module PullRequestTemplate
     module Hdi
       class GithubAuditRuleTest < Minitest::Test
+        # The stub classes define WayOfWorking::Audit purely for this test. Remove it and
+        # unload the stub afterwards so each test starts without the registry already defined,
+        # regardless of the order the suite runs in.
+        def teardown
+          WayOfWorking.send(:remove_const, :Audit) if WayOfWorking.const_defined?(:Audit, false)
+          $LOADED_FEATURES.reject! { |path| path.end_with?('test/way_of_working/audit_github_stub_classes.rb') }
+        end
+
         def test_the_rule_is_registered
           # Check that the GitHub audit registry is unavailable by default
           refute Object.const_defined?('WayOfWorking::Audit::Github::Rules::Registry')

--- a/test/way_of_working/versioning/semver/generators/init_test.rb
+++ b/test/way_of_working/versioning/semver/generators/init_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+module WayOfWorking
+  module Versioning
+    module Semver
+      module Generators
+        # This class tests the Versioning::Init Thor Group (generator)
+        class InitTest < Rails::Generators::TestCase
+          tests WayOfWorking::Versioning::Semver::Generators::Init
+          destination WayOfWorking.root.join('tmp/generators')
+          setup :prepare_destination
+
+          test 'generator runs without errors' do
+            assert_nothing_raised do
+              run_generator
+            end
+          end
+
+          test 'files are created and revoked' do
+            run_generator
+
+            assert_file 'docs/way_of_working/versioning.md'
+
+            run_generator [], behavior: :revoke
+
+            assert_no_file 'docs/way_of_working/versioning.md'
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/versioning/semver/github_audit_rule_test.rb
+++ b/test/way_of_working/versioning/semver/github_audit_rule_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'way_of_working/versioning/semver/github_audit_rule'
+
+module WayOfWorking
+  module Versioning
+    module Semver
+      class GithubAuditRuleTest < Minitest::Test
+        # The rule registers itself with the (now built-in) GitHub audit registry
+        # at load time. Unregister it afterwards so the shared registry doesn't
+        # leak between tests, regardless of the order the suite runs in.
+        def teardown
+          ::WayOfWorking::Audit::Github::Rules::Registry.rules&.delete_if { |_, klass| klass == GithubAuditRule }
+        end
+
+        def test_the_rule_is_registered
+          assert ::WayOfWorking::Audit::Github::Rules::Registry.rules.values.include?(GithubAuditRule)
+          assert_equal [:way_of_working], GithubAuditRule.tags
+        end
+      end
+    end
+  end
+end

--- a/test/way_of_working/zeitwerk_test_loader_test.rb
+++ b/test/way_of_working/zeitwerk_test_loader_test.rb
@@ -14,7 +14,6 @@ module WayOfWorking
       @loader.inflector = Zeitwerk::GemInflector.new(@root.join('lib/way_of_working.rb'))
       @loader.push_dir(@root.join('test'))
       @loader.ignore(@root.join('test/test_helper.rb'))
-      @loader.ignore(@root.join('test/way_of_working/audit_github_stub_classes.rb'))
       @loader.setup
     end
 

--- a/way_of_working.gemspec
+++ b/way_of_working.gemspec
@@ -38,8 +38,11 @@ Gem::Specification.new do |spec|
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
   spec.add_dependency 'activesupport'
+  spec.add_dependency 'faraday-multipart', '~> 1.0'
+  spec.add_dependency 'faraday-retry', '~> 2.2'
   spec.add_dependency 'git', '~> 1.13'
   spec.add_dependency 'nokogiri'
+  spec.add_dependency 'octokit', '~> 9.1'
   spec.add_dependency 'rainbow', '~> 3.1'
   spec.add_dependency 'thor', '~> 1.2'
   spec.add_dependency 'zeitwerk', '~> 2.6.18'


### PR DESCRIPTION
## Summary

Continues bundling previously-separate plugin gems into this gem as **opt-in built-in features**, adds the GitHub audit framework, and documents how the gem is versioned now that features live in-tree:

- **Pull Request Template (HDI)** — `require 'way_of_working/pull_request_template/hdi'`
- **Code of Conduct (Contributor Covenant)** — `require 'way_of_working/code_of_conduct/contributor_covenant'`
- **Versioning (Semantic Versioning)** — `require 'way_of_working/versioning/semver'`
- **Audit (GitHub)** — a framework of rules to check GitHub repo content/configuration, with each feature contributing its own audit rule.

Each bundled feature ships its generators, GitHub audit rule, templates and docs, and exposes the same subcommands as before.

## Versioning policy

Documents the decision that SemVer governs the gem's **interface** (CLI, require paths, plugin API), not the content its generators emit:

- Refreshing the standard a feature embeds (e.g. a new Contributor Covenant or MADR version) is **minor**, not major — so the major version stays meaningful and `~> N.0` pins keep working.
- Drastic standard upgrades ship as **additive variants** under the `category/variant` namespace, so existing users are untouched.
- See [ADR-0001](docs/decisions/0001-version-the-gem-interface-not-generated-content.md) and `CONTRIBUTING.md` (new) for the version-bump checklist.

## Notes

- README: new **Versioning Policy** section; feature table rows for Code of Conduct, Pull Request Template, Audit and Versioning updated to `Built-in (...)`.
- CHANGELOG: Unreleased entries for the bundled features, scoped with a per-feature prefix.
- Made the `github_audit_rule` tests order-independent (teardown removes the shared audit-registry stub).

## Testing

- `bundle exec rake test` — green (60 runs, 0 failures)
- `npx alex docs/decisions/0001-...md` — no issues