### PR TITLE
Release prep for v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-06-05
+
 ### Added
 
 - **Audit:** bundled the GitHub audit feature into this gem. It is opt in and replaces the separate `way_of_working-audit-github` plugin gem.
@@ -72,7 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Corrected use of relative paths in the rubocop config file
 
-[unreleased]: https://github.com/HealthDataInsight/way_of_working/compare/v2.0.1...HEAD
+[unreleased]: https://github.com/HealthDataInsight/way_of_working/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/HealthDataInsight/way_of_working/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/HealthDataInsight/way_of_working/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/HealthDataInsight/way_of_working/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/HealthDataInsight/way_of_working/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0] - 2026-06-05
+## [2.1.0] - 2026-06-08
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ way_of_working init pull_request_template
 
 #### Versioning
 
-A shared versioning standard makes software changes easy to communicate and releases predictable to manage across projects, so consumers can reason about compatibility at a glance.
+A shared versioning standard makes software changes clear to communicate and releases predictable to manage across projects, so consumers can reason about compatibility at a glance.
 
 This feature documents [Semantic Versioning v2.0.0] as the project's versioning standard. Enable it by requiring it:
 

--- a/code_safety.yml
+++ b/code_safety.yml
@@ -23,7 +23,7 @@ file safety:
   ".github/linters/rubocop_defaults.yml":
     comments:
     reviewed_by: timgentry
-    safe_revision: e136e6fb3abdc99545ef0b8da050b3331a4737fd
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   ".github/pull_request_template.md":
     comments:
     reviewed_by: timgentry
@@ -31,15 +31,15 @@ file safety:
   ".github/workflows/inclusive-language.yml":
     comments:
     reviewed_by: timgentry
-    safe_revision: e136e6fb3abdc99545ef0b8da050b3331a4737fd
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   ".github/workflows/main.yml":
     comments:
-    reviewed_by: shilpigoeldev
-    safe_revision: a332d01447a4c74991ee7cf1d4e64a9e6b5d32c8
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   ".github/workflows/mega-linter.yml":
     comments:
-    reviewed_by: shilpigoeldev
-    safe_revision: a332d01447a4c74991ee7cf1d4e64a9e6b5d32c8
+    reviewed_by: timgentry
+    safe_revision: 850d1ad013c692beb482edef7210cbb8b2178067
   ".gitignore":
     comments:
     reviewed_by: timgentry
@@ -47,11 +47,11 @@ file safety:
   ".mega-linter.yml":
     comments:
     reviewed_by: timgentry
-    safe_revision: e136e6fb3abdc99545ef0b8da050b3331a4737fd
+    safe_revision: 850d1ad013c692beb482edef7210cbb8b2178067
   ".mise.toml":
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   ".rubocop":
     comments:
     reviewed_by: timgentry
@@ -59,7 +59,7 @@ file safety:
   ".ruby-version":
     comments:
     reviewed_by: timgentry
-    safe_revision: 720ad0fe1167e39fb0e85fa2355809fdfce1a370
+    safe_revision: 0c9e1c025cf51e9bfa28d3a594055006edf9d000
   CHANGELOG.md:
     comments:
     reviewed_by: shilpigoeldev
@@ -70,20 +70,20 @@ file safety:
     safe_revision: 4830ed99a857f3bf781bcf21bff6a2d5510fbcc7
   CONTRIBUTING.md:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   Gemfile:
     comments:
     reviewed_by: timgentry
-    safe_revision: 3530bbc21f30419e40a8f6eb73b42b3e8c906921
+    safe_revision: 0c9e1c025cf51e9bfa28d3a594055006edf9d000
   LICENSE.txt:
     comments:
     reviewed_by: timgentry
     safe_revision: 50f34ef4f776c94ead81d272a7ae94b6048dcb03
   README.md:
     comments:
-    reviewed_by: shilpigoeldev
-    safe_revision: 3b8ad6e7a3079bbde987a48cfe0fc56d87d423a6
+    reviewed_by: timgentry
+    safe_revision: 703ce590ebf5c0bbb731a95dd6622b6d99c809f9
   Rakefile:
     comments:
     reviewed_by: brian.shand
@@ -106,8 +106,8 @@ file safety:
     safe_revision: bfff11bf026610401b997b8413fa98b87e8a12df
   docs/decisions/0001-version-the-gem-interface-not-generated-content.md:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   docs/decisions/README.md:
     comments:
     reviewed_by: timgentry
@@ -126,36 +126,36 @@ file safety:
     safe_revision: e136e6fb3abdc99545ef0b8da050b3331a4737fd
   lib/way_of_working.rb:
     comments:
-    reviewed_by: shilpigoeldev
-    safe_revision: 573e46b243ed291512bf9c0fdaa9048d956ac326
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/audit/github.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/audit/github/auditor.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/audit/github/generators/exec.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/audit/github/rules/base.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/audit/github/rules/registry.rb:
     comments: Identical to file reviewed in way_of_working-audit-github@4f2b65e6f3eda6c9213348886916aa391cd2e295
     reviewed_by: shilpigoeldev
     safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/audit/github/rules/unknown.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/changelog/keepachangelog.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/changelog/keepachangelog/generators/init.rb:
     comments:
     reviewed_by:
@@ -174,12 +174,12 @@ file safety:
     safe_revision: bdbb7c9aed37d5be109e2bbc2c2fc9adc849aa16
   lib/way_of_working/code_of_conduct/contributor_covenant.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/code_of_conduct/contributor_covenant/generators/init.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/code_of_conduct/contributor_covenant/github_audit_rule.rb:
     comments: Identical to file reviewed in way_of_working-code_of_conduct-contributor_covenant@b2c63ee5cf0f603c0a71813a04946323cc8c37a8
     reviewed_by: shilpigoeldev
@@ -198,20 +198,20 @@ file safety:
     safe_revision: 573e46b243ed291512bf9c0fdaa9048d956ac326
   lib/way_of_working/decision_record/madr.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/decision_record/madr/generators/init.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/decision_record/madr/generators/new.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/decision_record/madr/github_audit_rule.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/decision_record/madr/templates/.github/ISSUE_TEMPLATE/decision-record.md:
     comments: Identical to file reviewed in way_of_working-decision_record-madr@726c543149db70831ba9892789e93f7cb9bf6317
     reviewed_by: shilpigoeldev
@@ -234,28 +234,28 @@ file safety:
     safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/decision_record/madr/templates/docs/way_of_working/decision-records.md:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/git/repo_reader.rb:
     comments:
     reviewed_by: timgentry
-    safe_revision: e136e6fb3abdc99545ef0b8da050b3331a4737fd
+    safe_revision: 0c9e1c025cf51e9bfa28d3a594055006edf9d000
   lib/way_of_working/git/summary_tag.rb:
     comments:
     reviewed_by: brian.shand
     safe_revision: 1cd0f0429c60c0666c1ddb905afbeb3f67a88a0e
   lib/way_of_working/inclusive_language/alex.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/inclusive_language/alex/generators/exec.rb:
     comments: Identical to file reviewed in way_of_working-inclusive_language-alex@cbe4ccee99e97402a6b17a3453d80fde37311328
     reviewed_by: shilpigoeldev
     safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/inclusive_language/alex/generators/init.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/inclusive_language/alex/github_audit_rule.rb:
     comments: Identical to file reviewed in way_of_working-inclusive_language-alex@d340a14df1545bacb5e851ba8687275992e41709
     reviewed_by: shilpigoeldev
@@ -270,8 +270,8 @@ file safety:
     safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/inclusive_language/alex/templates/.github/workflows/inclusive-language.yml:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/inclusive_language/alex/templates/docs/way_of_working/inclusive-language.md:
     comments: Identical to file reviewed in way_of_working-inclusive_language-alex@cbe4ccee99e97402a6b17a3453d80fde37311328
     reviewed_by: timgentry
@@ -282,24 +282,24 @@ file safety:
     safe_revision: bdbb7c9aed37d5be109e2bbc2c2fc9adc849aa16
   lib/way_of_working/pull_request_template/hdi.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/pull_request_template/hdi/generators/init.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/pull_request_template/hdi/github_audit_rule.rb:
     comments: Identical to file reviewed in way_of_working-pull_request_template-hdi@8a1c4e75959cd233ba1b9f134f792a112c642452
     reviewed_by: shilpigoeldev
     safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/pull_request_template/hdi/templates/.github/pull_request_template.md:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/pull_request_template/hdi/templates/docs/way_of_working/pull-request-template-and-guidelines.md:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/readme_badge.rb:
     comments:
     reviewed_by: shilpigoeldev
@@ -314,8 +314,8 @@ file safety:
     safe_revision: a332d01447a4c74991ee7cf1d4e64a9e6b5d32c8
   lib/way_of_working/readme_badge/paths.rb:
     comments:
-    reviewed_by: shilpigoeldev
-    safe_revision: 573e46b243ed291512bf9c0fdaa9048d956ac326
+    reviewed_by: timgentry
+    safe_revision: 0c9e1c025cf51e9bfa28d3a594055006edf9d000
   lib/way_of_working/readme_badge/templates/README.md:
     comments:
     reviewed_by: timgentry
@@ -350,24 +350,24 @@ file safety:
     safe_revision: a332d01447a4c74991ee7cf1d4e64a9e6b5d32c8
   lib/way_of_working/versioning/semver.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/versioning/semver/generators/init.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/versioning/semver/github_audit_rule.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/versioning/semver/templates/docs/way_of_working/versioning.md:
     comments: Identical to file reviewed in way_of_working-versioning-semver@ffc45545cd82db554cbee17125f2ed5c2c70ea2e
     reviewed_by: shilpigoeldev
     safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lychee.toml:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 850d1ad013c692beb482edef7210cbb8b2178067
   test/resources/empty_Rakefile:
     comments:
     reviewed_by: timgentry
@@ -398,97 +398,97 @@ file safety:
     safe_revision: 573e46b243ed291512bf9c0fdaa9048d956ac326
   test/way_of_working/audit/github/auditor_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working/audit/github/generators/exec_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working/audit/github/rule_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working/changelog/keepachangelog/generators/init_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   test/way_of_working/changelog/keepachangelog/github_audit_rule_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working/code_of_conduct/contributor_covenant/generators/init_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working/code_of_conduct/contributor_covenant/github_audit_rule_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working/decision_record/madr/generators/init_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   test/way_of_working/decision_record/madr/generators/new_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   test/way_of_working/decision_record/madr/github_audit_rule_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working/git/summary_tag_test.rb:
     comments:
     reviewed_by: shilpigoeldev
     safe_revision: a332d01447a4c74991ee7cf1d4e64a9e6b5d32c8
   test/way_of_working/inclusive_language/alex/generators/exec_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   test/way_of_working/inclusive_language/alex/generators/init_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   test/way_of_working/inclusive_language/alex/github_audit_rule_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working/pull_request_template/hdi/generators/init_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working/pull_request_template/hdi/github_audit_rule_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working/readme_badge/generators/init_test.rb:
     comments:
     reviewed_by: timgentry
     safe_revision: 573e46b243ed291512bf9c0fdaa9048d956ac326
   test/way_of_working/readme_badge/paths_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 0c9e1c025cf51e9bfa28d3a594055006edf9d000
   test/way_of_working/versioning/semver/generators/init_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working/versioning/semver/github_audit_rule_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working/zeitwerk_gem_loader_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 0c9e1c025cf51e9bfa28d3a594055006edf9d000
   test/way_of_working/zeitwerk_test_loader_test.rb:
     comments:
-    reviewed_by:
-    safe_revision:
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   test/way_of_working_test.rb:
     comments:
     reviewed_by: timgentry
     safe_revision: f96fc0fbe2d380210ac5a12d04db8140ebd5ea56
   way_of_working.gemspec:
     comments:
-    reviewed_by: shilpigoeldev
-    safe_revision: a332d01447a4c74991ee7cf1d4e64a9e6b5d32c8
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af

--- a/code_safety.yml
+++ b/code_safety.yml
@@ -48,6 +48,10 @@ file safety:
     comments:
     reviewed_by: timgentry
     safe_revision: e136e6fb3abdc99545ef0b8da050b3331a4737fd
+  ".mise.toml":
+    comments:
+    reviewed_by:
+    safe_revision:
   ".rubocop":
     comments:
     reviewed_by: timgentry
@@ -64,6 +68,10 @@ file safety:
     comments:
     reviewed_by: timgentry
     safe_revision: 4830ed99a857f3bf781bcf21bff6a2d5510fbcc7
+  CONTRIBUTING.md:
+    comments:
+    reviewed_by:
+    safe_revision:
   Gemfile:
     comments:
     reviewed_by: timgentry
@@ -96,6 +104,10 @@ file safety:
     comments:
     reviewed_by: brian.shand
     safe_revision: bfff11bf026610401b997b8413fa98b87e8a12df
+  docs/decisions/0001-version-the-gem-interface-not-generated-content.md:
+    comments:
+    reviewed_by:
+    safe_revision:
   docs/decisions/README.md:
     comments:
     reviewed_by: timgentry
@@ -116,14 +128,114 @@ file safety:
     comments:
     reviewed_by: shilpigoeldev
     safe_revision: 573e46b243ed291512bf9c0fdaa9048d956ac326
+  lib/way_of_working/audit/github.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/audit/github/auditor.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/audit/github/generators/exec.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/audit/github/rules/base.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/audit/github/rules/registry.rb:
+    comments: Identical to file reviewed in way_of_working-audit-github@4f2b65e6f3eda6c9213348886916aa391cd2e295
+    reviewed_by: shilpigoeldev
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
+  lib/way_of_working/audit/github/rules/unknown.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/changelog/keepachangelog.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/changelog/keepachangelog/generators/init.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/changelog/keepachangelog/github_audit_rule.rb:
+    comments: Identical to file reviewed in way_of_working-changelog-keepachangelog@8d28755cd6dce363b605f02a432539c7d6411c33
+    reviewed_by: shilpigoeldev
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
+  lib/way_of_working/changelog/keepachangelog/templates/docs/way_of_working/changelog.md:
+    comments: Identical to file reviewed in way_of_working-changelog-keepachangelog@8d28755cd6dce363b605f02a432539c7d6411c33
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/cli.rb:
     comments:
     reviewed_by: shilpigoeldev
     safe_revision: bdbb7c9aed37d5be109e2bbc2c2fc9adc849aa16
+  lib/way_of_working/code_of_conduct/contributor_covenant.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/code_of_conduct/contributor_covenant/generators/init.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/code_of_conduct/contributor_covenant/github_audit_rule.rb:
+    comments: Identical to file reviewed in way_of_working-code_of_conduct-contributor_covenant@b2c63ee5cf0f603c0a71813a04946323cc8c37a8
+    reviewed_by: shilpigoeldev
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
+  lib/way_of_working/code_of_conduct/contributor_covenant/templates/CODE_OF_CONDUCT.md.tt:
+    comments: Identical to file reviewed in way_of_working-code_of_conduct-contributor_covenant@08b322b4214e38cbce371b73463453628acd09b9
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
+  lib/way_of_working/code_of_conduct/contributor_covenant/templates/docs/way_of_working/code-of-conduct.md:
+    comments: Identical to file reviewed in way_of_working-code_of_conduct-contributor_covenant@03587db522e42ce5d2320ca6faf2e7d72fe80a95
+    reviewed_by: timgentry
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
   lib/way_of_working/configuration.rb:
     comments:
     reviewed_by: shilpigoeldev
     safe_revision: 573e46b243ed291512bf9c0fdaa9048d956ac326
+  lib/way_of_working/decision_record/madr.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/decision_record/madr/generators/init.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/decision_record/madr/generators/new.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/decision_record/madr/github_audit_rule.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/decision_record/madr/templates/.github/ISSUE_TEMPLATE/decision-record.md:
+    comments: Identical to file reviewed in way_of_working-decision_record-madr@726c543149db70831ba9892789e93f7cb9bf6317
+    reviewed_by: shilpigoeldev
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
+  lib/way_of_working/decision_record/madr/templates/docs/decisions/0000-use-markdown-any-decision-records.md:
+    comments: Identical to file reviewed in way_of_working-decision_record-madr@726c543149db70831ba9892789e93f7cb9bf6317
+    reviewed_by: shilpigoeldev
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
+  lib/way_of_working/decision_record/madr/templates/docs/decisions/README.md:
+    comments: Identical to file reviewed in way_of_working-decision_record-madr@726c543149db70831ba9892789e93f7cb9bf6317
+    reviewed_by: shilpigoeldev
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
+  lib/way_of_working/decision_record/madr/templates/docs/decisions/adr-template.md.tt:
+    comments: Identical to file reviewed in way_of_working-decision_record-madr@726c543149db70831ba9892789e93f7cb9bf6317
+    reviewed_by: shilpigoeldev
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
+  lib/way_of_working/decision_record/madr/templates/docs/decisions/index.md:
+    comments: Identical to file reviewed in way_of_working-decision_record-madr@726c543149db70831ba9892789e93f7cb9bf6317
+    reviewed_by: shilpigoeldev
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
+  lib/way_of_working/decision_record/madr/templates/docs/way_of_working/decision-records.md:
+    comments:
+    reviewed_by:
+    safe_revision:
   lib/way_of_working/git/repo_reader.rb:
     comments:
     reviewed_by: timgentry
@@ -132,10 +244,62 @@ file safety:
     comments:
     reviewed_by: brian.shand
     safe_revision: 1cd0f0429c60c0666c1ddb905afbeb3f67a88a0e
+  lib/way_of_working/inclusive_language/alex.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/inclusive_language/alex/generators/exec.rb:
+    comments: Identical to file reviewed in way_of_working-inclusive_language-alex@cbe4ccee99e97402a6b17a3453d80fde37311328
+    reviewed_by: shilpigoeldev
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
+  lib/way_of_working/inclusive_language/alex/generators/init.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/inclusive_language/alex/github_audit_rule.rb:
+    comments: Identical to file reviewed in way_of_working-inclusive_language-alex@d340a14df1545bacb5e851ba8687275992e41709
+    reviewed_by: shilpigoeldev
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
+  lib/way_of_working/inclusive_language/alex/templates/.alexignore:
+    comments: Identical to file reviewed in way_of_working-inclusive_language-alex@321bc80b15da3c679252c5a507115396d9fcbd25
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
+  lib/way_of_working/inclusive_language/alex/templates/.alexrc:
+    comments: Identical to file reviewed in way_of_working-inclusive_language-alex@cbe4ccee99e97402a6b17a3453d80fde37311328
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
+  lib/way_of_working/inclusive_language/alex/templates/.github/workflows/inclusive-language.yml:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/inclusive_language/alex/templates/docs/way_of_working/inclusive-language.md:
+    comments: Identical to file reviewed in way_of_working-inclusive_language-alex@cbe4ccee99e97402a6b17a3453d80fde37311328
+    reviewed_by: timgentry
+    safe_revision: a358d6d91594dcacdf45a3c4429f386df1acf861
   lib/way_of_working/paths.rb:
     comments:
     reviewed_by: shilpigoeldev
     safe_revision: bdbb7c9aed37d5be109e2bbc2c2fc9adc849aa16
+  lib/way_of_working/pull_request_template/hdi.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/pull_request_template/hdi/generators/init.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/pull_request_template/hdi/github_audit_rule.rb:
+    comments: Identical to file reviewed in way_of_working-pull_request_template-hdi@8a1c4e75959cd233ba1b9f134f792a112c642452
+    reviewed_by: shilpigoeldev
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
+  lib/way_of_working/pull_request_template/hdi/templates/.github/pull_request_template.md:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/pull_request_template/hdi/templates/docs/way_of_working/pull-request-template-and-guidelines.md:
+    comments:
+    reviewed_by:
+    safe_revision:
   lib/way_of_working/readme_badge.rb:
     comments:
     reviewed_by: shilpigoeldev
@@ -184,6 +348,26 @@ file safety:
     comments:
     reviewed_by: shilpigoeldev
     safe_revision: a332d01447a4c74991ee7cf1d4e64a9e6b5d32c8
+  lib/way_of_working/versioning/semver.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/versioning/semver/generators/init.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/versioning/semver/github_audit_rule.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  lib/way_of_working/versioning/semver/templates/docs/way_of_working/versioning.md:
+    comments: Identical to file reviewed in way_of_working-versioning-semver@ffc45545cd82db554cbee17125f2ed5c2c70ea2e
+    reviewed_by: shilpigoeldev
+    safe_revision: 05b4cd23bbfee89ec82e83c0763b3636c0d1c3af
+  lychee.toml:
+    comments:
+    reviewed_by:
+    safe_revision:
   test/resources/empty_Rakefile:
     comments:
     reviewed_by: timgentry
@@ -212,18 +396,94 @@ file safety:
     comments:
     reviewed_by: timgentry
     safe_revision: 573e46b243ed291512bf9c0fdaa9048d956ac326
+  test/way_of_working/audit/github/auditor_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/audit/github/generators/exec_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/audit/github/rule_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/changelog/keepachangelog/generators/init_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/changelog/keepachangelog/github_audit_rule_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/code_of_conduct/contributor_covenant/generators/init_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/code_of_conduct/contributor_covenant/github_audit_rule_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/decision_record/madr/generators/init_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/decision_record/madr/generators/new_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/decision_record/madr/github_audit_rule_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
   test/way_of_working/git/summary_tag_test.rb:
     comments:
     reviewed_by: shilpigoeldev
     safe_revision: a332d01447a4c74991ee7cf1d4e64a9e6b5d32c8
+  test/way_of_working/inclusive_language/alex/generators/exec_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/inclusive_language/alex/generators/init_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/inclusive_language/alex/github_audit_rule_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/pull_request_template/hdi/generators/init_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/pull_request_template/hdi/github_audit_rule_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
   test/way_of_working/readme_badge/generators/init_test.rb:
     comments:
     reviewed_by: timgentry
     safe_revision: 573e46b243ed291512bf9c0fdaa9048d956ac326
-  test/way_of_working/zeitwerk_loader_test.rb:
+  test/way_of_working/readme_badge/paths_test.rb:
     comments:
-    reviewed_by: shilpigoeldev
-    safe_revision: a332d01447a4c74991ee7cf1d4e64a9e6b5d32c8
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/versioning/semver/generators/init_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/versioning/semver/github_audit_rule_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/zeitwerk_gem_loader_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
+  test/way_of_working/zeitwerk_test_loader_test.rb:
+    comments:
+    reviewed_by:
+    safe_revision:
   test/way_of_working_test.rb:
     comments:
     reviewed_by: timgentry

--- a/lib/way_of_working/version.rb
+++ b/lib/way_of_working/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WayOfWorking
-  VERSION = '2.0.1'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
## What?

Prepares the v2.1.0 release: bumps `VERSION` to `2.1.0`, dates the CHANGELOG entry, refreshes `code_safety.yml` to cover files migrated from the now-bundled plugins, and tweaks one README sentence to clear an `alex` warning.

## Why?

The bundled audit / inclusive-language / decision-record / changelog features landed on `main` without a version bump or a clean code-safety review, so the gem can't be cut as-is. This PR closes that gap so v2.1.0 can ship.

## How?

- `lib/way_of_working/version.rb`: `2.0.1` → `2.1.0`.
- `CHANGELOG.md`: added the `[2.1.0]` heading + compare link, repointed `[unreleased]`.
- `code_safety.yml`: re-reviewed and bumped `safe_revision` for files touched by the plugin migration; added entries for `.mise.toml` and `CONTRIBUTING.md`.
- `README.md`: reworded the Versioning intro ("easy" → "clear") to satisfy the `alex` linter.

## Testing?

`bin/test` locally; CI covers lint + alex + mega-linter.